### PR TITLE
Fix col widths

### DIFF
--- a/lib/elixlsx.ex
+++ b/lib/elixlsx.ex
@@ -48,5 +48,16 @@ defmodule Elixlsx do
     wci = Elixlsx.Compiler.make_workbook_comp_info workbook
     :zip.create(filename, Elixlsx.Writer.create_files(workbook, wci))
   end
+
+
+  @doc ~S"""
+  Write a Workbook object to the binary
+  Returns a tuple containing a filename and the binary
+  """
+  @spec write_to_memory(Elixlsx.Workbook.t, String.t) :: {:ok, {String.t, binary}} | {:error, any()}
+  def write_to_memory(workbook, filename) do
+    wci = Elixlsx.Compiler.make_workbook_comp_info workbook
+    :zip.create(filename, Elixlsx.Writer.create_files(workbook, wci), [:memory])
+  end
 end
 

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -16,11 +16,12 @@ defmodule Elixlsx.Sheet do
   The property list describes formatting options for that
   cell. See Font.from_props/1 for a list of options.
   """
-  defstruct name: "", rows: [], col_widths: %{}
+  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}
   @type t :: %Sheet {
     name: String.t,
     rows: list(list(any())),
-    col_widths: %{pos_integer => number}
+    col_widths: %{pos_integer => number},
+    row_heights: %{pos_integer => number}
   }
 
   @doc ~S"""
@@ -124,5 +125,14 @@ defmodule Elixlsx.Sheet do
   def set_col_width(sheet, column, width) do
     update_in sheet.col_widths,
               &(Dict.put &1, Util.decode_col(column), width)
+  end
+
+  @spec set_row_height(Sheet.t, number, number) :: Sheet.t
+  @doc ~S"""
+  Set the row height for a given row. Row is indexed starting from 1
+  """
+  def set_row_height(sheet, row_idx, height) do
+    update_in sheet.row_heights,
+              &(Dict.put &1, row_idx, height)
   end
 end

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -196,14 +196,23 @@ defmodule Elixlsx.XMLTemplates do
   end
 
 
-  defp xl_sheet_rows(data, wci) do
+  defp xl_sheet_rows(data, row_heights, wci) do
     Enum.zip(data, 1 .. length data) |>
     Enum.map_join(fn {row, rowidx} ->
               """
-              <row r="#{rowidx}">
+              <row r="#{rowidx}" #{get_row_height_attr(row_heights, rowidx)}>
                 #{xl_sheet_cols(row, rowidx, wci)}
               </row>
               """ end)
+  end
+
+  defp get_row_height_attr(row_heights, rowidx) do
+    row_height = Dict.get(row_heights, rowidx)
+    if (row_height) do
+      "ht=\"#{row_height}\""
+    else
+    ""
+    end
   end
 
   defp make_col_width({k, v}) do
@@ -245,7 +254,7 @@ defmodule Elixlsx.XMLTemplates do
   <sheetData>
   """ 
   <>
-  xl_sheet_rows(sheet.rows, wci)
+  xl_sheet_rows(sheet.rows, sheet.row_heights, wci)
   <>
   ~S"""
   </sheetData>

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -211,7 +211,7 @@ defmodule Elixlsx.XMLTemplates do
   end
 
   defp make_col_widths(sheet) do
-    if Dict.size sheet.col_widths do
+    if Dict.size(sheet.col_widths) != 0 do
       cols = Dict.to_list(sheet.col_widths)
       |> Enum.sort
       |> Enum.map_join &make_col_width/1


### PR DESCRIPTION
From what I understand Elixir all values except `false` and `nil` (so including `0`) will evaluate to `true`
[http://elixir-examples.github.io/examples/boolean-operators](http://elixir-examples.github.io/examples/boolean-operators)

Before that, all generated files without set column widths contained empty `<cols></cols>` tags which was treated under windows as wrong xlsx format.

Thanks to @jakubsta !