### PR TITLE
Support horizontal alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elixlsx
 
+[![Hex Version](http://img.shields.io/hexpm/v/elixlsx.svg?style=flat)](https://hex.pm/packages/elixlsx)
+
 A writer for XLSX files.
 
 Supports:

--- a/example.exs
+++ b/example.exs
@@ -49,7 +49,11 @@ sheet3 = %Sheet{name: "Second", rows:
    # (see row_heights below).
    [["This is a cell with quite a bit of text.", wrap_text: true]],
 # Unicode should work as well:
-   [["Müłti", bold: true, italic: true, underline: true, strike: true]]
+   [["Müłti", bold: true, italic: true, underline: true, strike: true]],
+# Change horizontal alignment 
+   [["left", align_horizontal: :left], ["right", align_horizontal: :right],
+    ["center", align_horizontal: :center], ["justify", align_horizontal: :justify],
+    ["general", align_horizontal: :general], ["fill", align_horizontal: :fill]]
   ],
   row_heights: %{4 => 60}}
 

--- a/lib/elixlsx/style/font.ex
+++ b/lib/elixlsx/style/font.ex
@@ -9,12 +9,14 @@ defmodule Elixlsx.Style.Font do
   - underline: boolean
   - strike: boolean
   - size: pos_integer
+  - color: (Hex-)String
   - wrap_text: boolean
+  - align_horizontal: atom (:left, :right, :center, :justify, :general, :fill)
 
   """
   alias __MODULE__
   defstruct bold: false, italic: false, underline: false,
-  strike: false, size: nil, color: nil, wrap_text: false
+  strike: false, size: nil, color: nil, wrap_text: false, align_horizontal: nil
 
   @type t :: %Font{
     bold: boolean,
@@ -23,7 +25,8 @@ defmodule Elixlsx.Style.Font do
     strike: boolean,
     size: pos_integer,
     color: String.t,
-    wrap_text: boolean
+    wrap_text: boolean,
+    align_horizontal: atom
   }
 
 
@@ -37,7 +40,8 @@ defmodule Elixlsx.Style.Font do
                strike: !!props[:strike],
                size: props[:size],
                color: props[:color],
-               wrap_text: !!props[:wrap_text]
+               wrap_text: !!props[:wrap_text],
+               align_horizontal: props[:align_horizontal]
               }
 
     if ft == %Font{}, do: nil, else: ft


### PR DESCRIPTION
I'm missing some alignment functions. This PR will add the `align_horizontal` option.
Available values are `:left`, `:right`, `:center`, `:justify`, `:general`, `:fill`

And I add a hex shield to the README ;-)
