### PR TITLE
Fix double escaping issue

### DIFF
--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -281,8 +281,7 @@ defmodule Elixlsx.XMLTemplates do
   """
   <> Enum.map_join(stringlist, fn ({_, value}) ->
     # the only two characters that *must* be replaced for safe XML encoding are & and <:
-    value_ = (value |> String.replace("&", "&amp;") |> String.replace("<", "&lt;"))
-    "<si><t>#{minimal_xml_text_escape value_}</t></si>"
+    "<si><t>#{minimal_xml_text_escape value}</t></si>"
   end)
   <> "</sst>"
   end


### PR DESCRIPTION
Currently the following is rendered in the XML:

![panoramix_ _vim_test_lib_](https://cloud.githubusercontent.com/assets/486512/17608866/f4d26298-6072-11e6-88f8-b1b985138b7a.png)

Which results in the following output:

![nfp_donation_report_us](https://cloud.githubusercontent.com/assets/486512/17608855/e5df7d66-6072-11e6-8d0d-20b97aac366b.png)

