### PR TITLE
Change border style to resolve Excel for Mac issue

### DIFF
--- a/lib/elixlsx/style/border_style.ex
+++ b/lib/elixlsx/style/border_style.ex
@@ -70,7 +70,7 @@ defmodule Elixlsx.Style.BorderStyle do
 
     """
     <border diagonalUp="#{diagonal_up}" diagonalDown="#{diagonal_down}">
-      #{top}#{bottom}#{left}#{right}#{diagonal}
+      #{left}#{right}#{top}#{bottom}#{diagonal}
     </border>
     """
   end


### PR DESCRIPTION
After some experimentation I found that this change resolved the problem I encountered opening files generate by elixlsx in Excel for Mac. See this issue for more detail: https://github.com/xou/elixlsx/issues/17.

I was concerned that this change might break other Excel editors. I couldn't find a schema definition that seemed relevant so I created a simple spreadsheet in Google Sheets. I exported the Google Sheet as xlsx, extracted the content and took a look at styles.xml. This is the relevant part I found:
```
<borders count="1">
  <border>
    <left/>
    <right/>
    <top/>
    <bottom/>
  </border>
</borders>
```
Seeing that Google Sheets exports xlsx files with the borders ordered left, right, top, bottom as proposed in my PR gave me confidence that this ordering is likely the most compatible if it's what Google Sheet generates.