### PR TITLE
Fix some Elixir 1.4 warnings (barewords)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule Elixlsx.Mixfile do
     [app: :elixlsx,
      version: "0.1.0",
      elixir: "~> 1.1",
-     package: package,
+     package: package(),
      description: "a writer for XLSX spreadsheet files",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
I'm getting warnings when running my own app code from the bareword function calls inside this library's `mix.exs`. Fixed in this pull request. There may be other locations where this fix needs to be made, but at least this will stop some pesky warnings.