### PR TITLE
Formula support & Fix background issue 

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -25,6 +25,15 @@ sheet1 = Sheet.with_name("First")
          |> Sheet.set_col_width("A", 18.0)
 # Cell borders
          |> Sheet.set_cell("A5", "Double border", border: [bottom: [style: :double, color: "#cc3311"]])
+# Formula
+         |> Sheet.set_cell("E1", 1.2, num_format: "0.00")
+         |> Sheet.set_cell("E2", 2, num_format: "0.00")
+         |> Sheet.set_cell("E3", 3.5, num_format: "0.00")
+         |> Sheet.set_cell("E4", 4, num_format: "0.00")
+         |> Sheet.set_cell("E5", 5, num_format: "0.00")
+         |> Sheet.set_cell("E8", {:formula, "SUM(C1:C5)"}, num_format: "0.00", bold: true)
+         |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
+         |> Sheet.set_col_width("F", 18.0)
 
 workbook = %Workbook{sheets: [sheet1]}
 

--- a/lib/elixlsx/compiler/fill_db.ex
+++ b/lib/elixlsx/compiler/fill_db.ex
@@ -12,8 +12,8 @@ defmodule Elixlsx.Compiler.FillDB do
   @spec register_fill(FillDB.t, Fill.t) :: FillDB.t
   def register_fill(filldb, fill) do
     case Dict.fetch(filldb.fills, fill) do
-      :error -> %FillDB{fills: Dict.put(filldb.fills, fill, filldb.element_count + 1),
-                       element_count: filldb.element_count + 1}
+      :error -> %FillDB{fills: Dict.put(filldb.fills, fill, filldb.element_count + 2),
+                       element_count: filldb.element_count + 2}
       {:ok, _} -> filldb
     end
   end

--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -210,6 +210,13 @@ defmodule Elixlsx.Util do
     {:excelts, value}
   end
 
+  @doc ~S"""
+  Formula's value calculate on opening excel programm. We don't need to format this here.
+  """
+  @spec to_excel_datetime({:formula, String.t}) :: {:formula, String.t}
+  def to_excel_datetime({:formula, value}) do
+    {:formula, value}
+  end
 
   @doc ~S"""
   replace_all(input, [{search, replace}])

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -155,6 +155,8 @@ defmodule Elixlsx.XMLTemplates do
     case content do
       {:excelts, num} ->
         {"n", to_string(num)}
+      {:formula, x} ->
+        {:formula, x}
       x when is_number(x) ->
         {"n", to_string(x)}
       x when is_binary(x) ->
@@ -191,12 +193,22 @@ defmodule Elixlsx.XMLTemplates do
                                     }
           end
 
-          """
-          <c r="#{U.to_excel_coords(rowidx, colidx)}"
-          s="#{styleID}" t="#{content_type}">
-          <v>#{content_value}</v>
-          </c>
-          """
+          case content_type do
+            :formula ->
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}">
+              <f>#{content_value}</f>
+              </c>
+              """
+            type ->
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}" t="#{type}">
+              <v>#{content_value}</v>
+              </c>
+              """
+          end
           end
         end) |>
     List.foldr("", &<>/2)

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -468,8 +468,9 @@ defmodule Elixlsx.XMLTemplates do
     <font />
     #{make_font_list(font_list)}
   </fonts>
-  <fills count="#{1 + length fill_list}">
+  <fills count="#{2 + length fill_list}">
     <fill><patternFill patternType="none"/></fill>
+    <fill><patternFill patternType="gray125"/></fill>
     #{make_fill_list(fill_list)}
   </fills>
   <borders count="#{1 + length borders_list}">


### PR DESCRIPTION
Sorry for the long waiting time, I had some trouble with my computer..

At first I added the formula content type (issue #16). This can be used with `Sheet.set_cell("XY", {:formula, "FUNCTION"})`. I add some examples to the file. 
I noticed only a problem with the `Util.to_excel_datetime/1` function. Are here other functions to check with the new function?

On last commit I fix an issue with background color on Microsoft Excel. The first and second colors are reserved and can not overriden. 

I hope I did not forget anything.

Tested on:
Microsoft Excel for Mac 15.30 (current version)
Libre Office 5.2.5.1 on Mac
Numbers 4.0.5 on Mac
