### PR TITLE
Formula default value

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -31,8 +31,9 @@ sheet1 = Sheet.with_name("First")
          |> Sheet.set_cell("E3", 3.5, num_format: "0.00")
          |> Sheet.set_cell("E4", 4, num_format: "0.00")
          |> Sheet.set_cell("E5", 5, num_format: "0.00")
-         |> Sheet.set_cell("E8", {:formula, "SUM(C1:C5)"}, num_format: "0.00", bold: true)
+         |> Sheet.set_cell("E8", {:formula, "SUM(CE1:E5)"}, num_format: "0.00", bold: true)
          |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
+         |> Sheet.set_cell("F8", {:formula, "SUM(1,2,3)", value: "6"}) # Show `value` if there is no calculated value (example: Mac OS preview)
          |> Sheet.set_col_width("F", 18.0)
 
 workbook = %Workbook{sheets: [sheet1]}

--- a/example.exs
+++ b/example.exs
@@ -31,9 +31,8 @@ sheet1 = Sheet.with_name("First")
          |> Sheet.set_cell("E3", 3.5, num_format: "0.00")
          |> Sheet.set_cell("E4", 4, num_format: "0.00")
          |> Sheet.set_cell("E5", 5, num_format: "0.00")
-         |> Sheet.set_cell("E8", {:formula, "SUM(CE1:E5)"}, num_format: "0.00", bold: true)
+         |> Sheet.set_cell("E6", {:formula, "SUM(E1:E5)", value: 15.70}, num_format: "0.00", bold: true) # Show `value` if there is no calculated value (example: Mac OS preview)
          |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
-         |> Sheet.set_cell("F8", {:formula, "SUM(1,2,3)", value: "6"}) # Show `value` if there is no calculated value (example: Mac OS preview)
          |> Sheet.set_col_width("F", 18.0)
 
 workbook = %Workbook{sheets: [sheet1]}

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -157,6 +157,8 @@ defmodule Elixlsx.XMLTemplates do
         {"n", to_string(num)}
       {:formula, x} ->
         {:formula, x}
+      {:formula, x, opts} when is_list(opts) ->
+        {:formula, x, opts}
       x when is_number(x) ->
         {"n", to_string(x)}
       x when is_binary(x) ->
@@ -183,9 +185,10 @@ defmodule Elixlsx.XMLTemplates do
           end
 
           cv = get_content_type_value(content, wci)
-          {content_type, content_value} =
+          {content_type, content_value, content_opts} =
           case cv do
-            {t, v} -> {t, v}
+            {t, v} -> {t, v, []}
+            {t, v, opts} -> {t, v, opts}
             :error -> raise %ArgumentError{
                         message: "Invalid column content at " <>
                                     U.to_excel_coords(rowidx, colidx) <> ": "
@@ -195,10 +198,15 @@ defmodule Elixlsx.XMLTemplates do
 
           case content_type do
             :formula ->
+              if not is_nil(content_opts[:value]) do
+                value = "<v>#{content_opts[:value]}</v>"
+              end
+
               """
               <c r="#{U.to_excel_coords(rowidx, colidx)}"
               s="#{styleID}">
               <f>#{content_value}</f>
+              #{value}
               </c>
               """
             type ->

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -198,9 +198,7 @@ defmodule Elixlsx.XMLTemplates do
 
           case content_type do
             :formula ->
-              if not is_nil(content_opts[:value]) do
-                value = "<v>#{content_opts[:value]}</v>"
-              end
+              value = if not is_nil(content_opts[:value]), do: "<v>#{content_opts[:value]}</v>", else: ""
 
               """
               <c r="#{U.to_excel_coords(rowidx, colidx)}"

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -530,7 +530,7 @@ defmodule Elixlsx.XMLTemplates do
   <> workbook_sheet_entries(data.sheets, sci)
   <> ~S"""
   </sheets>
-  <calcPr iterateCount="100" refMode="A1" iterate="false" iterateDelta="0.001"/>
+  <calcPr fullCalcOnLoad="1" iterateCount="100" refMode="A1" iterate="false" iterateDelta="0.001"/>
   </workbook>
   """
   end


### PR DESCRIPTION
The missing commits for issue #16 contain
- Add the `fullCalcOnLoad` value
- Allow default values on formulas

I think we should add a description for the topic default-value anywhere, but I'm not sure which place should be good for this and how describe the problematic simple.

Followed calls are now valid:
`Sheet.set_cell("XY", {:formula, "SUM(1,2,3)"})`
`Sheet.set_cell("XY", {:formula, "SUM(1,2,3)", value: "6"})`

Tested behavior with default value:
Microsoft Excel: Calcluate
Libre Office: **NOT** Calculate
Numbers: Calculate

Tested on:
Microsoft Excel for Mac 15.31
Libre Office 5.2.5.1 on Mac
Numbers 4.0.5 on Mac
