### PR TITLE
Fix filldb index

### DIFF
--- a/lib/elixlsx/compiler/fill_db.ex
+++ b/lib/elixlsx/compiler/fill_db.ex
@@ -13,7 +13,7 @@ defmodule Elixlsx.Compiler.FillDB do
   def register_fill(filldb, fill) do
     case Dict.fetch(filldb.fills, fill) do
       :error -> %FillDB{fills: Dict.put(filldb.fills, fill, filldb.element_count + 2),
-                       element_count: filldb.element_count + 2}
+                       element_count: filldb.element_count + 1}
       {:ok, _} -> filldb
     end
   end


### PR DESCRIPTION
When issue with background cell styles in Excel was fixed a new bug was introduced that accidentally increased the `element_count` in `filldb` with 2 making every addition count as two. This resulted in sheets with multiple backgrounds styles only the ones indexing at a multiple of two actually got applied (however wrongly), the rest was left without styling.

This fixes the `element_count` to only count each new addition as one. Verified to work in both Excel and LibreOffice.