### PR TITLE
Fix "repair file" bug due to invalid (and stale) AppVersion tag.

### DIFF
--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -236,5 +236,14 @@ defmodule Elixlsx.Util do
   def replace_all(input, []) do
     input
   end
+
+
+  @version Mix.Project.config[:version]
+  @doc ~S"""
+  Returns the application version suitable for the <ApplicationVersion> tag.
+  """
+  def app_version_string do 
+    String.replace(@version, ~r/(\d+)\.(\d+)\.(\d+)/, "\\1.\\2\\3")
+  end
 end
 

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -51,15 +51,19 @@ defmodule Elixlsx.XMLTemplates do
                        {">", "&gt;"} ])
   end
 
+
   @docprops_app ~S"""
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
   <TotalTime>0</TotalTime>
   <Application>Elixlsx</Application>
-  <AppVersion>0.0.6</AppVersion>
+  <AppVersion>__APPVERSION__</AppVersion>
 </Properties>
 """
-  def docprops_app, do: @docprops_app
+  def docprops_app do
+    U.replace_all(@docprops_app,
+                  [{"__APPVERSION__", U.app_version_string()}])
+  end
 
 
   @docprops_core ~S"""


### PR DESCRIPTION
This should fix #26 (Excel on mac complains about invalid file), and that the appversion tag was hardcoded at 0.0.6.

The problem seems to be that only one "dot" is allowed in the AppVersion tag. This commit takes the current version from mix.exs and removes the second dot.