### PR TITLE
Sheet name length validation

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -3,7 +3,7 @@ defmodule Elixlsx.Sheet do
   alias Elixlsx.Sheet
   alias Elixlsx.Util
   @moduledoc ~S"""
-  Describes a single sheet with a given name.
+  Describes a single sheet with a given name. The name can be up to 31 characters long.
   The rows property is a list, each corresponding to a
   row (from the top), of lists, each corresponding to
   a column (from the left), of contents.
@@ -27,6 +27,7 @@ defmodule Elixlsx.Sheet do
 
   @doc ~S"""
   Create a sheet with a sheet name.
+  The name can be up to 31 characters long.
   """
   @spec with_name(String.t) :: Sheet.t
   def with_name(name) do

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -100,6 +100,10 @@ defmodule Elixlsx.XMLTemplates do
   ### xl/workbook.xml
   @spec make_xl_workbook_xml_sheet_entry({Sheet.t, SheetCompInfo.t}) :: String.t
   def make_xl_workbook_xml_sheet_entry {sheet_info, sheet_comp_info} do
+    if String.length(sheet_info.name) > 31 do
+      raise %ArgumentError{message: "The sheet name '#{sheet_info.name}' is too long. Maximum 31 chars allowed for name."}
+    end
+    
     """
 <sheet name="#{sheet_info.name}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{sheet_comp_info.rId}"/>
     """

--- a/test/elixlsx_test.exs
+++ b/test/elixlsx_test.exs
@@ -15,6 +15,8 @@ defmodule ElixlsxTest do
   alias Elixlsx.XMLTemplates
   alias Elixlsx.Compiler.StringDB
   alias Elixlsx.Style.Font
+  alias Elixlsx.Workbook
+  alias Elixlsx.Sheet
 
   def xpath(el, path) do
     :xmerl_xpath.string(to_char_list(path), el)
@@ -85,5 +87,13 @@ defmodule ElixlsxTest do
     [name] = :xmerl_xpath.string('/font/name/@val', xmerl)
 
     assert xmlAttribute(name, :value) == 'Arial'
+  end
+
+  test "too long sheet name" do
+    sheet1 = Sheet.with_name("This is a very looong sheet name")
+    assert_raise ArgumentError, ~r/The sheet name .* is too long. Maximum 31 chars allowed for name./, fn ->
+      %Workbook{sheets: [sheet1]}
+      |> Elixlsx.write_to("test.xlsx")
+    end
   end
 end


### PR DESCRIPTION
Hey, here the solution for issue #28.

Microsoft's Excel allows only sheet names with maximal length of 31 chars. The most libraries throws an exception if the name is longer than 31 chars. I think this is the best solution to handle this.

- Added validation and error
- Added test case
- Added info to documentation