### PR TITLE
Support cells with content of :empty to allow easier formatting.

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -25,6 +25,8 @@ sheet1 = Sheet.with_name("First")
          |> Sheet.set_col_width("A", 18.0)
 # Cell borders
          |> Sheet.set_cell("A5", "Double border", border: [bottom: [style: :double, color: "#cc3311"]])
+# Formatting with empty content
+         |> Sheet.set_cell("A5", :empty, bg_color: "#ffff00", border: [bottom: [style: :double, color: "#cc3311"]])
 # Formula
          |> Sheet.set_cell("E1", 1.2, num_format: "0.00")
          |> Sheet.set_cell("E2", 2, num_format: "0.00")

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -167,6 +167,8 @@ defmodule Elixlsx.XMLTemplates do
         {"n", to_string(x)}
       x when is_binary(x) ->
         {"s", to_string(StringDB.get_id wci.stringdb, x)}
+      :empty ->
+        {:empty, :empty}
       true ->
         :error
     end
@@ -209,6 +211,12 @@ defmodule Elixlsx.XMLTemplates do
               s="#{styleID}">
               <f>#{content_value}</f>
               #{value}
+              </c>
+              """
+            :empty ->
+              """
+              <c r="#{U.to_excel_coords(rowidx, colidx)}"
+              s="#{styleID}">
               </c>
               """
             type ->


### PR DESCRIPTION
I wanted to be able to format cells only - without any content. I suggested in this fork supporting a content atom value of :empty to do this. The change to the XMLTemplate logic was simple to detect this and not generate the unneeded <v> element.