### PR TITLE
Fixes for compatibility with Elixir 1.5 / OTP 20.0

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "excheck": {:hex, :excheck, "0.5.1", "c4cb6d08ed4b6109b03707dac3be95190c2ee1a49d773f66048385160f73908b", [:mix], []},
+  "excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], [], "hexpm"},
   "triq": {:git, "https://github.com/triqng/triq.git", "2c497398e020e06db8496f1d89f12481cc5adab9", []}}


### PR DESCRIPTION
* Upgrades excheck to 0.5.3

This upgrade is necessary because as of Elixir 
1.4, all ExUnit CLI formatters must use the 
GenServer API (instead of the former GenEvent API)
. Newer versions of this lib account for this 
change.

* Agnostic parsing of content with escaped values

:xmerl_scan parses inner text with escaped values
(like ampersand) in different ways depending on 
the version of the runtime. In older versions, 
the parser splits on the escaped value. This
commit refactors the test to turn this part of the
test agnostic.