### PR TITLE
Add additional control for showGridLines

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -93,5 +93,9 @@ sheet4
 |> Sheet.set_pane_freeze(2, 1) # first and second row and first column frozen
 |> Sheet.remove_pane_freeze # unfreeze pane
 
+sheet5 = %Sheet{name: "No gridlines shown", show_grid_lines: false}
+         |> Sheet.set_at(0, 0, "Just this cell")
+
 Workbook.append_sheet(workbook, sheet4)
+|> Workbook.append_sheet(sheet5)
 |> Elixlsx.write_to("example.xlsx")

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -16,14 +16,15 @@ defmodule Elixlsx.Sheet do
   The property list describes formatting options for that
   cell. See Font.from_props/1 for a list of options.
   """
-  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, merge_cells: [], pane_freeze: nil
+  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, merge_cells: [], pane_freeze: nil, show_grid_lines: true
   @type t :: %Sheet {
     name: String.t,
     rows: list(list(any())),
     col_widths: %{pos_integer => number},
     row_heights: %{pos_integer => number},
     merge_cells: [],
-    pane_freeze: {number, number}
+    pane_freeze: {number, number},
+    show_grid_lines: boolean()
   }
 
   @doc ~S"""

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -298,7 +298,9 @@ defmodule Elixlsx.XMLTemplates do
   </sheetPr>
   <dimension ref="A1"/>
   <sheetViews>
-    <sheetView workbookViewId="0">
+    <sheetView workbookViewId="0"
+    """ <> make_sheet_show_grid(sheet) <> """
+    >
       """ <> make_sheetview(sheet) <> """
     </sheetView>
   </sheetViews>
@@ -319,6 +321,14 @@ defmodule Elixlsx.XMLTemplates do
     """
   end
 
+  defp make_sheet_show_grid(sheet) do
+    show_grid_lines_xml = case sheet.show_grid_lines do
+      false -> "showGridLines=\"0\" "
+      _ -> ""
+    end
+    show_grid_lines_xml
+  end
+
   defp make_sheetview(sheet) do
     {selection_pane_attr, panel_xml} = case sheet.pane_freeze do
       {row_idx, col_idx} ->
@@ -327,6 +337,7 @@ defmodule Elixlsx.XMLTemplates do
       nil ->
         {"", ""}
     end
+
     panel_xml <> "<selection " <> selection_pane_attr <> " activeCell=\"A1\" sqref=\"A1\" />"
   end
 


### PR DESCRIPTION
Suggesting this patch to support turning off the grid lines on a worksheet. Default is to leave the current behavior, but adding the new show_grid_lines: false to the sheet structure allows an override.