### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/lib/elixlsx.ex
+++ b/lib/elixlsx.ex
@@ -46,7 +46,7 @@ defmodule Elixlsx do
   @spec write_to(Elixlsx.Workbook.t, String.t) :: {:ok, String.t} | {:error, any()}
   def write_to(workbook, filename) do
     wci = Elixlsx.Compiler.make_workbook_comp_info workbook
-    :zip.create(filename, Elixlsx.Writer.create_files(workbook, wci))
+    :zip.create(to_charlist(filename), Elixlsx.Writer.create_files(workbook, wci))
   end
 
 
@@ -57,7 +57,7 @@ defmodule Elixlsx do
   @spec write_to_memory(Elixlsx.Workbook.t, String.t) :: {:ok, {String.t, binary}} | {:error, any()}
   def write_to_memory(workbook, filename) do
     wci = Elixlsx.Compiler.make_workbook_comp_info workbook
-    :zip.create(filename, Elixlsx.Writer.create_files(workbook, wci), [:memory])
+    :zip.create(to_charlist(filename), Elixlsx.Writer.create_files(workbook, wci), [:memory])
   end
 end
 

--- a/lib/elixlsx/compiler/workbook_comp_info.ex
+++ b/lib/elixlsx/compiler/workbook_comp_info.ex
@@ -17,7 +17,7 @@ defmodule Elixlsx.Compiler.WorkbookCompInfo do
   next_free_xl_rid: nil
 
   @type t :: %Compiler.WorkbookCompInfo{
-    sheet_info: Compiler.SheetCompInfo.t,
+    sheet_info: [Compiler.SheetCompInfo.t],
     stringdb: Compiler.StringDB.t,
     fontdb: Compiler.FontDB.t,
     filldb: Compiler.FillDB.t,

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -23,7 +23,7 @@ defmodule Elixlsx.Sheet do
     col_widths: %{pos_integer => number},
     row_heights: %{pos_integer => number},
     merge_cells: [],
-    pane_freeze: {number, number}
+    pane_freeze: {number, number} | nil
   }
 
   @doc ~S"""

--- a/lib/elixlsx/workbook.ex
+++ b/lib/elixlsx/workbook.ex
@@ -12,7 +12,7 @@ defmodule Elixlsx.Workbook do
   defstruct sheets: [], datetime: nil
   @type t :: %Workbook{
     sheets: nonempty_list(Sheet.t),
-    datetime: Elixlsx.Util.calendar
+    datetime: String.t | integer | nil
   }
 
   @doc "Append a sheet at the end."

--- a/lib/elixlsx/writer.ex
+++ b/lib/elixlsx/writer.ex
@@ -6,7 +6,7 @@ defmodule Elixlsx.Writer do
   alias Elixlsx.Compiler.SheetCompInfo
   alias Elixlsx.Workbook
 
-  @type zip_tuple :: {char_list, String.t}
+  @type zip_tuple :: {charlist, String.t}
 
   @moduledoc ~S"""
   Contains functions to generate the individual files
@@ -109,7 +109,7 @@ defmodule Elixlsx.Writer do
 
   @spec sheet_full_path(SheetCompInfo.t) :: list(char)
   defp sheet_full_path sci do
-    String.to_char_list "xl/worksheets/#{sci.filename}"
+    String.to_charlist "xl/worksheets/#{sci.filename}"
   end
 
   @spec get_xl_worksheets_dir(Workbook.t, WorkbookCompInfo.t)

--- a/lib/elixlsx/writer.ex
+++ b/lib/elixlsx/writer.ex
@@ -70,7 +70,7 @@ defmodule Elixlsx.Writer do
   end
 
 
-  @spec get_xl_rels_dir(any, SheetCompInfo.t, non_neg_integer) :: list(zip_tuple)
+  @spec get_xl_rels_dir(any, [SheetCompInfo.t], non_neg_integer) :: list(zip_tuple)
   def get_xl_rels_dir(_, sheetCompInfos, next_rId) do
     [{'xl/_rels/workbook.xml.rels',
       ~S"""
@@ -94,7 +94,7 @@ defmodule Elixlsx.Writer do
      XMLTemplates.make_xl_styles wci}
   end
 
-  @spec get_xl_workbook_xml(Workbook.t, SheetCompInfo.t) :: zip_tuple
+  @spec get_xl_workbook_xml(Workbook.t, [SheetCompInfo.t]) :: zip_tuple
   def get_xl_workbook_xml(data, sheetCompInfos) do
     {'xl/workbook.xml',
      XMLTemplates.make_workbook_xml(data, sheetCompInfos)}

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Elixlsx.Mixfile do
       {:excheck, "~> 0.5", only: :test},
       {:triq, github: "triqng/triq", only: :test},
       {:credo, "~> 0.5", only: [:dev, :test]},
-      {:ex_doc, "~> 0.14", only: [:dev]}
+      {:ex_doc, "~> 0.14", only: [:dev]},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], [], "hexpm"},


### PR DESCRIPTION
Hi, thanks for creating Elixlsx!

These changes gets elixlsx passing dialyzer on my development environment.

The important changes for my project are the `Elixlsx.write_to` and `Elixlsx.write_to_memory`, since dialyzer warns that calls into these functions will never return, forcing me to suppress the warning in my project.