### PR TITLE
fix pane in sheetView

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -142,7 +142,8 @@ defmodule Elixlsx.Sheet do
 
   @spec set_pane_freeze(Sheet.t, number, number) :: Sheet.t
   @doc ~S"""
-  Set the pane freeze at the given row and column. Row and column are indexed starting from 1
+  Set the pane freeze at the given row and column. Row and column are indexed starting from 1.
+  Special value 0 means no freezing, e.g. {1, 0} will freeze first row and no columns.
   """
   def set_pane_freeze(sheet, row_idx, col_idx) do
      %{sheet | pane_freeze: {row_idx, col_idx}}


### PR DESCRIPTION
we can't use bottomRight in every case because spec (ISO/IEC
29500-1:2016) forbids using bottomRight when only one split
(horizontal or vertical) is applied

for horizontal split proper values are bottomLeft and topLeft
for vertical split proper values are topLeft and topRight

also MS Word for Mac OS display 'corrupted document' notification when
only horizontal split is applied, and bottomRight pane is set

fixes #54