### PR TITLE
Escaping sheet name

### DIFF
--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -105,7 +105,7 @@ defmodule Elixlsx.XMLTemplates do
     end
     
     """
-<sheet name="#{sheet_info.name}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{sheet_comp_info.rId}"/>
+<sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{sheet_comp_info.rId}"/>
     """
   end
 


### PR DESCRIPTION
Fix for #52.

Escaping special chars in sheet name. The number of chars that be allowed are not affected (tested on macOS).