### PR TITLE
Downgrade required elixir version for travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: elixir
 
 elixir:
-  - 1.5.0
+  - 1.3.0
 
 otp_release:
   - 19.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 ## Installation
 
 
-### Elixir 1.5 and above
+### Elixir 1.3 and above
 
 Via hex, in mix.exs:
 
@@ -39,7 +39,7 @@ defp deps do
 end
 ```
 
-### Elixir pre 1.5
+### Elixir pre 1.3
 
 ```Elixir
 defp deps do

--- a/README.md
+++ b/README.md
@@ -21,15 +21,11 @@ Features:
 
 Via hex, in mix.exs:
 
-<!--
-If library is bumped to version 0.4.0 else this can be removed
-
 ```Elixir
 defp deps do
   [{:elixlsx, "~> 0.4.0"}]
 end
 ```
--->
 
 Via github:
 

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -342,7 +342,7 @@ defmodule Elixlsx.XMLTemplates do
     # * when only vertical split is applied we need to use topRight
     # * and when both splits is applied, we can use bottomRight
     pane = case sheet.pane_freeze do
-      {row_idx, 0} ->
+      {_row_idx, 0} ->
         "bottomLeft"
       {0, _col_idx} ->
         "topRight"

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Elixlsx.Mixfile do
 
   def project do
     [app: :elixlsx,
-     version: "0.3.1",
-     elixir: "~> 1.5",
+     version: "0.4.0",
+     elixir: "~> 1.3",
      package: package(),
      description: "a writer for XLSX spreadsheet files",
      build_embedded: Mix.env == :prod,

--- a/test/elixlsx_test.exs
+++ b/test/elixlsx_test.exs
@@ -20,11 +20,11 @@ defmodule ElixlsxTest do
   alias Elixlsx.Sheet
 
   def xpath(el, path) do
-    :xmerl_xpath.string(to_char_list(path), el)
+    :xmerl_xpath.string(to_charlist(path), el)
   end
 
   defp xml_inner_strings(xml, path) do
-    {xmerl, []} = :xmerl_scan.string String.to_char_list(xml)
+    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
 
     Enum.map(
       xpath(xmerl, path),
@@ -65,7 +65,7 @@ defmodule ElixlsxTest do
     xml = Font.from_props(color: "#012345") |>
     Font.get_stylexml_entry
 
-    {xmerl, []} = :xmerl_scan.string String.to_char_list(xml)
+    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
 
     [color] = :xmerl_xpath.string('/font/color/@rgb', xmerl)
 
@@ -76,7 +76,7 @@ defmodule ElixlsxTest do
     xml = Font.from_props(font: "Arial") |>
     Font.get_stylexml_entry
 
-    {xmerl, []} = :xmerl_scan.string String.to_char_list(xml)
+    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
 
     [name] = :xmerl_xpath.string('/font/name/@val', xmerl)
 

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -5,7 +5,7 @@ defmodule ExCheck.UtilTest do
   alias Elixlsx.Util
 
   property :enc_dec do
-    for_all x in such_that(x in int when x >= 0) do
+    for_all x in such_that(x in int() when x >= 0) do
       implies x >= 0 do
         Util.decode_col(Util.encode_col(x)) == x
       end


### PR DESCRIPTION
@goravbhootra FYI, I'm lowering the required version to 1.3 as 1.3 is the newest version available in Ubuntu and it seems to address the warnings emitted by elixir 1.1. Let me know if you have concerns.