### PR TITLE
Basic support for boolean values in cells. Fixes #65

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -27,6 +27,8 @@ sheet1 = Sheet.with_name("First")
          |> Sheet.set_cell("A5", "Double border", border: [bottom: [style: :double, color: "#cc3311"]])
 # Formatting with empty content
          |> Sheet.set_cell("A5", :empty, bg_color: "#ffff00", border: [bottom: [style: :double, color: "#cc3311"]])
+# Boolean value
+         |> Sheet.set_cell("A6", true)
 # Formula
          |> Sheet.set_cell("E1", 1.2, num_format: "0.00")
          |> Sheet.set_cell("E2", 2, num_format: "0.00")

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -172,6 +172,8 @@ defmodule Elixlsx.XMLTemplates do
         {"n", to_string(x)}
       x when is_binary(x) ->
         {"s", to_string(StringDB.get_id wci.stringdb, x)}
+      x when is_boolean(x) ->
+        {"b", if x do "1" else "0" end}
       :empty ->
         {:empty, :empty}
       true ->


### PR DESCRIPTION
Google Docs and Office Online display value properly. Calc shows 1 or 0. OOC itself uses special number format for boolean fields to support localized values: 
```xml
<numFmt numFmtId="169" formatCode="&quot;TRUE&quot;;&quot;TRUE&quot;;&quot;FALSE&quot;"/>
```
Most xlsx-libraries I found ignore it.