### PR TITLE
Allow hiding of sheets in workbook

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -16,7 +16,7 @@ defmodule Elixlsx.Sheet do
   The property list describes formatting options for that
   cell. See Font.from_props/1 for a list of options.
   """
-  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, merge_cells: [], pane_freeze: nil, show_grid_lines: true
+  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, merge_cells: [], pane_freeze: nil, show_grid_lines: true, hidden: false
   @type t :: %Sheet {
     name: String.t,
     rows: list(list(any())),
@@ -24,7 +24,8 @@ defmodule Elixlsx.Sheet do
     row_heights: %{pos_integer => number},
     merge_cells: [],
     pane_freeze: {number, number} | nil,
-    show_grid_lines: boolean()
+    show_grid_lines: boolean(),
+    hidden: boolean()
   }
 
   @doc ~S"""
@@ -155,5 +156,13 @@ defmodule Elixlsx.Sheet do
   """
   def remove_pane_freeze(sheet) do
     %{sheet | pane_freeze: nil}
+  end
+
+  @spec set_hidden(Sheet.t(), boolean) :: Sheet.t()
+  @doc ~S"""
+  Sets a sheet as hidden.
+  """
+  def set_hidden(sheet, is_hidden) do
+    %{sheet | hidden: is_hidden}
   end
 end

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -104,8 +104,10 @@ defmodule Elixlsx.XMLTemplates do
       raise %ArgumentError{message: "The sheet name '#{sheet_info.name}' is too long. Maximum 31 chars allowed for name."}
     end
 
+    state = if sheet_info.hidden, do: "invisible", else: "visible"
+
     """
-    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{sheet_comp_info.rId}"/>
+    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="#{ state }" r:id="#{sheet_comp_info.rId}"/>
     """
   end
 


### PR DESCRIPTION
As per Mike's suggestion. We now generate the weekly summary for a report in the same way as the monthly summary, but in order not to spam the report with many unnecessary sheets, I have made it so the weekly raw data sheets are hidden.

This involves changing this dependency to allow this functionality.