### PR TITLE
row/col outline level (grouping) support

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -101,7 +101,7 @@ sheet5 = %Sheet{name: "No gridlines shown", show_grid_lines: false}
 # Rows/columns can be grouped.
 sheet6 = %Sheet{
   name: "Row and Column Groups",
-  rows: 1..100 |> Enum.chunk_every(10),
+  rows: 1..100 |> Enum.chunk(10),
   group_rows: [{2..3, collapsed: true}, 6..7],  # collapse and hide rows 2 to 3
   group_cols: [2..9, 2..5]  # nest
 }

--- a/example.exs
+++ b/example.exs
@@ -98,6 +98,16 @@ sheet4
 sheet5 = %Sheet{name: "No gridlines shown", show_grid_lines: false}
          |> Sheet.set_at(0, 0, "Just this cell")
 
+# Rows/columns can be grouped.
+sheet6 = %Sheet{
+  name: "Row and Column Groups",
+  rows: 1..100 |> Enum.chunk_every(10),
+  group_rows: [{2..3, collapsed: true}, 6..7],  # collapse and hide rows 2 to 3
+  group_cols: [2..9, 2..5]  # nest
+}
+|> Sheet.group_cols("C", "D")  # nest further
+
 Workbook.append_sheet(workbook, sheet4)
 |> Workbook.append_sheet(sheet5)
+|> Workbook.append_sheet(sheet6)
 |> Elixlsx.write_to("example.xlsx")

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -16,12 +16,14 @@ defmodule Elixlsx.Sheet do
   The property list describes formatting options for that
   cell. See Font.from_props/1 for a list of options.
   """
-  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, merge_cells: [], pane_freeze: nil, show_grid_lines: true
+  defstruct name: "", rows: [], col_widths: %{}, row_heights: %{}, col_outline_levels: %{}, row_outline_levels: %{}, merge_cells: [], pane_freeze: nil, show_grid_lines: true
   @type t :: %Sheet {
     name: String.t,
     rows: list(list(any())),
     col_widths: %{pos_integer => number},
     row_heights: %{pos_integer => number},
+    col_outline_levels: %{pos_integer => pos_integer},
+    row_outline_levels: %{pos_integer => pos_integer},
     merge_cells: [],
     pane_freeze: {number, number} | nil,
     show_grid_lines: boolean()
@@ -138,6 +140,25 @@ defmodule Elixlsx.Sheet do
   def set_row_height(sheet, row_idx, height) do
     update_in sheet.row_heights,
               &(Map.put &1, row_idx, height)
+  end
+
+  @spec set_col_outline_level(Sheet.t, String.t, pos_integer) :: Sheet.t
+  @doc ~S"""
+  Set the column outline level for a given column. Column is indexed by
+  name ("A", ...)
+  """
+  def set_col_outline_level(sheet, column, outline_level) do
+    update_in sheet.col_outline_levels,
+              &(Map.put &1, Util.decode_col(column), outline_level)
+  end
+
+  @spec set_row_outline_level(Sheet.t, number, pos_integer) :: Sheet.t
+  @doc ~S"""
+  Set the row outline level for a given row. Row is indexed starting from 1
+  """
+  def set_row_outline_level(sheet, row_idx, outline_level) do
+    update_in sheet.row_outline_levels,
+              &(Map.put &1, row_idx, outline_level)
   end
 
   @spec set_pane_freeze(Sheet.t, number, number) :: Sheet.t

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -22,12 +22,13 @@ defmodule Elixlsx.Sheet do
     rows: list(list(any())),
     col_widths: %{pos_integer => number},
     row_heights: %{pos_integer => number},
-    group_cols: list(Range.t(pos_integer, pos_integer)),
-    group_rows: list(Range.t(pos_integer, pos_integer)),
+    group_cols: list(rowcol_group),
+    group_rows: list(rowcol_group),
     merge_cells: [],
     pane_freeze: {number, number} | nil,
     show_grid_lines: boolean()
   }
+  @type rowcol_group :: Range.t | {Range.t, opts :: keyword}
 
   @doc ~S"""
   Create a sheet with a sheet name.
@@ -146,20 +147,30 @@ defmodule Elixlsx.Sheet do
   @doc ~S"""
   Group given column range. (i.e. increase outline level by one)
   Column is indexed by name ("A", ...)
+
+  ## Options
+
+    - `collapsed`: if true, collapse this group.
   """
-  def group_cols(sheet, first_col, last_col) do
+  def group_cols(sheet, first_col, last_col, opts \\ []) do
     col_range = Range.new(Util.decode_col(first_col), Util.decode_col(last_col))
-    update_in(sheet.group_cols, fn groups -> groups ++ [col_range] end)
+    new_group = if opts === [], do: col_range, else: {col_range, opts}
+    update_in(sheet.group_cols, fn groups -> groups ++ [new_group] end)
   end
 
   @spec group_rows(Sheet.t, pos_integer, pos_integer) :: Sheet.t
   @doc ~S"""
   Group given row range. (i.e. increase outline level by one)
   Row is indexed starting from 1.
+
+  ## Options
+
+    - `collapsed`: if true, collapse this group.
   """
-  def group_rows(sheet, first_row_idx, last_row_idx) do
+  def group_rows(sheet, first_row_idx, last_row_idx, opts \\ []) do
     row_range = Range.new(first_row_idx, last_row_idx)
-    update_in(sheet.group_rows, fn groups -> groups ++ [row_range] end)
+    new_group = if opts === [], do: row_range, else: {row_range, opts}
+    update_in(sheet.group_rows, fn groups -> groups ++ [new_group] end)
   end
 
   @spec set_pane_freeze(Sheet.t, number, number) :: Sheet.t

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -253,14 +253,23 @@ defmodule Elixlsx.XMLTemplates do
       """
   end
 
-  defp xl_sheet_rows(data, row_heights, row_outline_levels, wci) do
-    Enum.zip(data, 1 .. length data) |>
-    Enum.map_join(fn {row, rowidx} ->
+  defp xl_sheet_rows(data, row_heights, grouping_info, wci) do
+    rows =
+      Enum.zip(data, 1 .. length data) |>
+      Enum.map_join(fn {row, rowidx} ->
               """
-              <row r="#{rowidx}" #{get_row_height_attr(row_heights, rowidx)} #{get_row_outline_level_attr(row_outline_levels, rowidx)}>
+              <row r="#{rowidx}" #{get_row_height_attr(row_heights, rowidx)}#{get_row_grouping_attr(grouping_info, rowidx)}>
                 #{xl_sheet_cols(row, rowidx, wci)}
               </row>
               """ end)
+
+    if (length(data) + 1) in grouping_info.collapsed_idxs do
+      rows <> """
+      <row r="#{length(data) + 1}" collapsed="1"></row>
+      """
+    else
+      rows
+    end
   end
 
   defp get_row_height_attr(row_heights, rowidx) do
@@ -272,49 +281,84 @@ defmodule Elixlsx.XMLTemplates do
     end
   end
 
-  defp get_row_outline_level_attr(row_outline_levels, rowidx) do
-    row_outline_level = Map.get(row_outline_levels, rowidx)
-    if (row_outline_level) do
-      "outlineLevel=\"#{row_outline_level}\""
-    else
-      ""
-    end
+  defp get_row_grouping_attr(gr_info, rowidx) do
+    outline_level = Map.get(gr_info.outline_lvs, rowidx)
+    (if outline_level, do: " outlineLevel=\"#{outline_level}\"", else: "")
+    <>
+    (if rowidx in gr_info.hidden_idxs, do: " hidden=\"1\"", else: "")
+    <>
+    (if rowidx in gr_info.collapsed_idxs, do: " collapsed=\"1\"", else: "")
   end
 
-  defp groups_to_outline_levels(groups) do
-    Stream.concat(groups)
-    |> Enum.group_by(& &1)
-    |> Map.new(fn {k, v} -> {k, length(v)} end)
+  @typep grouping_info :: %{
+    outline_lvs: %{optional(idx :: pos_integer) => lv :: pos_integer},
+    hidden_idxs: MapSet.t(pos_integer),
+    collapsed_idxs: MapSet.t(pos_integer)
+  }
+  @spec get_grouping_info([Sheet.rowcol_group]) :: grouping_info
+  defp get_grouping_info(groups) do
+    ranges =
+      Enum.map(groups, fn
+        {%Range{} = range, _opts} -> range
+        %Range{} = range -> range
+      end)
+
+    collapsed_ranges =
+      groups
+      |> Enum.filter(fn
+        {%Range{} = _range, opts} -> opts[:collapsed]
+        %Range{} = _range -> false
+      end)
+      |> Enum.map(fn {range, _opts} -> range end)
+
+    # see ECMA Office Open XML Part1, 18.3.1.73 Row -> attributes -> collapsed for examples
+    %{
+      outline_lvs:
+        ranges
+        |> Stream.concat()
+        |> Enum.group_by(& &1)
+        |> Map.new(fn {k, v} -> {k, length(v)} end),
+      hidden_idxs:
+        collapsed_ranges |> Stream.concat() |> MapSet.new(),
+      collapsed_idxs:
+        collapsed_ranges |> Enum.map(& &1.last + 1) |> MapSet.new()
+    }
   end
 
-  defp make_col({k, width, outline_level}) do
+  defp make_col({k, width, outline_level, hidden, collapsed}) do
     width_attr =
-      if width do
-        " width=\"#{width}\" customWidth=\"1\""
-      else
-        ""
-      end
+      if width, do: " width=\"#{width}\" customWidth=\"1\"", else: ""
+    hidden_attr = if hidden, do: " hidden=\"1\"", else: ""
     outline_level_attr =
-      if outline_level do
-        " outlineLevel=\"#{outline_level}\""
-      else
-        ""
-      end
-    '<col min="#{k}" max="#{k}"#{width_attr}#{outline_level_attr} />'
+      if outline_level, do: " outlineLevel=\"#{outline_level}\"", else: ""
+    collapsed_attr =
+      if collapsed, do: " collapsed=\"1\"", else: ""
+
+    '<col min="#{k}" max="#{k}"#{width_attr}#{hidden_attr}#{outline_level_attr}#{collapsed_attr} />'
   end
 
   defp make_cols(sheet) do
-    col_outline_levels = groups_to_outline_levels(sheet.group_cols)
+    grouping_info = get_grouping_info(sheet.group_cols)
+    col_indices =
+      Stream.concat([
+        Map.keys(sheet.col_widths),
+        Map.keys(grouping_info.outline_lvs),
+        grouping_info.hidden_idxs,
+        grouping_info.collapsed_idxs
+      ])
+      |> Enum.sort()
+      |> Enum.dedup()
 
-    if Kernel.map_size(sheet.col_widths) != 0 or Kernel.map_size(col_outline_levels) != 0 do
-      col_indices =
-        (Map.keys(sheet.col_widths) ++ Map.keys(col_outline_levels))
-        |> Enum.sort()
-        |> Enum.dedup()
-
+    unless Enum.empty?(col_indices) do
       cols =
         col_indices
-        |> Stream.map(&({&1, Map.get(sheet.col_widths, &1), Map.get(col_outline_levels, &1)}))
+        |> Stream.map(&({
+          &1,
+          Map.get(sheet.col_widths, &1),
+          Map.get(grouping_info.outline_lvs, &1),
+          &1 in grouping_info.hidden_idxs,
+          &1 in grouping_info.collapsed_idxs
+        }))
         |> Enum.map_join(&make_col/1)
 
       "<cols>#{cols}</cols>"
@@ -340,7 +384,7 @@ defmodule Elixlsx.XMLTemplates do
   Returns the XML content for single sheet.
   """
   def make_sheet(sheet, wci) do
-    row_outline_levels = groups_to_outline_levels(sheet.group_rows)
+    grouping_info = get_grouping_info(sheet.group_rows)
 
     ~S"""
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -362,7 +406,7 @@ defmodule Elixlsx.XMLTemplates do
     </sheetViews>
     <sheetFormatPr defaultRowHeight="12.8"
     """
-    <> make_max_outline_level_row(row_outline_levels) <>
+    <> make_max_outline_level_row(grouping_info.outline_lvs) <>
     """
     />
     """
@@ -371,7 +415,7 @@ defmodule Elixlsx.XMLTemplates do
     <sheetData>
     """
     <>
-    xl_sheet_rows(sheet.rows, sheet.row_heights, row_outline_levels, wci)
+    xl_sheet_rows(sheet.rows, sheet.row_heights, grouping_info, wci)
     <>
     ~S"""
     </sheetData>


### PR DESCRIPTION
Hi. Thank you for providing this wonderful library, which is so simple to use! (I also use Python's openpyxl, but tired of its messy API...)

I personally had a work where I had to group rows/columns, just like the following article:
https://oxen.tech/blog/grouping-excel/

I forked xlixlsx and made some changes to do this.
I'd appreciate it if you review and merge my changes so that everyone can use this feature via Hex!

Your comments and edits are very appreciated.