### PR TITLE
cleaner, faster code in decode_col fn

### DIFF
--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -1,5 +1,5 @@
 defmodule Elixlsx.Util do
-  @col_alphabet to_string(Enum.to_list(?A..?Z))
+  @col_alphabet Enum.to_list(?A..?Z)
 
   @doc ~S"""
   returns the column letter(s) associated with a column index. Col idx starts at 1.
@@ -53,14 +53,12 @@ defmodule Elixlsx.Util do
   @spec decode_col_(String.t) :: non_neg_integer
   defp decode_col_("") do 0 end
   defp decode_col_(s) do
-    alphabet_list = String.to_charlist @col_alphabet
-
     if !String.match? s, ~r/^[A-Z]*$/ do
       raise %ArgumentError{message: "Invalid column string: " <> inspect s}
     end
 
     # translate list of strings to the base-26 value they represent
-    Enum.map(String.to_charlist(s), (fn x -> :string.chr(alphabet_list, x) end)) |>
+    Enum.map(String.to_charlist(s), (fn x -> :string.chr(@col_alphabet, x) end)) |>
     # multiply and aggregate them
     List.foldl(0, (fn (x, acc) -> x + 26 * acc end))
   end


### PR DESCRIPTION
The module attribute @col_alphabet is a charlist, which is converted to a binary using to_string/1. However, in decode_col_/1, it is converted back to a charlist before being used. It is never used in its binary form. The removal of the redundant conversions, which has no change in functionality, increases the speed of decode_col_/1 by about 10% (measured with Benchee).

If a string is passed as an arg to decode_col, it is checked using String.valid? and String.match?. The elimination of the first check using guard clauses, which has no change in functionality, increases the speed of decode_col/1 by about another 10% (for string args, with no change in speed for charlist args).

The if clause has been changed to a case clause to make the code paths more clear, with no change in logic.

