### PR TITLE
get triq dep from hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Elixlsx.Mixfile do
   defp deps do
     [
       {:excheck, "~> 0.5", only: :test},
-      {:triq, git: "https://gitlab.com/triq/triq.git", ref: "2c497398e020e06db8496f1d89f12481cc5adab9", only: :test},
+      {:triq, "~> 1.0", only: :test},
       {:credo, "~> 0.5", only: [:dev, :test]},
       {:ex_doc, "~> 0.19", only: [:dev]},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "triq": {:git, "https://gitlab.com/triq/triq.git", "2c497398e020e06db8496f1d89f12481cc5adab9", [ref: "2c497398e020e06db8496f1d89f12481cc5adab9"]},
+  "triq": {:hex, :triq, "1.3.0", "d9ed60f3cd2b6bacbb721bc9873e67e07b02e5b97c63d40db35b12670a7f1bf4", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
The triq package is hosted on hex (latest version 1.3), so there is no need to get the dependency from a git repository.
