### PR TITLE
Allow column style to be set in addition to column width

### DIFF
--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -272,20 +272,33 @@ defmodule Elixlsx.XMLTemplates do
     end
   end
 
-  defp make_col_width({k, v}) do
-    '<col min="#{k}" max="#{k}" width="#{v}" customWidth="1" />'
+  defp make_col_range(key) do
+    key_str = Integer.to_string(key)
+    [" min=\"", key_str, "\" max=\"", key_str, "\""]
   end
 
-  defp make_col_widths(sheet) do
-    if Kernel.map_size(sheet.col_widths) != 0 do
-      cols = Map.to_list(sheet.col_widths)
-      |> Enum.sort
-      |> Enum.map_join(&make_col_width/1)
+  defp make_col_width(%{width: width}) do
+    [" width=\"", Integer.to_string(width), "\" customWidth=\"1\""]
+  end
+  defp make_col_width(_), do: []
 
-      "<cols>#{cols}</cols>"
-    else
-      ""
-    end
+  defp make_cols(%{cols: cols}) when cols == %{}, do: ""
+  defp make_cols(%{cols: cols}) do
+    [
+      "<cols>",
+      Map.to_list(cols)
+      |> Enum.sort()
+      |> Enum.map(fn {key, props} -> [
+        "<col",
+        make_col_range(key),
+        make_col_width(props),
+        "/>"
+      ]
+      end),
+      "</cols>"
+    ]
+    # remove to output as iolist instead of string
+    |> Enum.join()
   end
 
   @spec make_sheet(Sheet.t, WorkbookCompInfo.t) :: String.t
@@ -313,7 +326,7 @@ defmodule Elixlsx.XMLTemplates do
     </sheetViews>
     <sheetFormatPr defaultRowHeight="12.8"/>
     """
-    <> make_col_widths(sheet) <>
+    <> make_cols(sheet) <>
     """
     <sheetData>
     """

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -277,13 +277,20 @@ defmodule Elixlsx.XMLTemplates do
     [" min=\"", key_str, "\" max=\"", key_str, "\""]
   end
 
+  defp make_col_style(props, _) when props == %{}, do: []
+  defp make_col_style(%{width: w} = props, _) when props == %{width: w}, do: []
+  defp make_col_style(props, wci) do
+    style_id = CellStyleDB.get_id(wci.cellstyledb, CellStyle.from_props(props))
+    [" style=\"", Integer.to_string(style_id), "\""]
+  end
+  
   defp make_col_width(%{width: width}) do
     [" width=\"", Integer.to_string(width), "\" customWidth=\"1\""]
   end
   defp make_col_width(_), do: []
 
-  defp make_cols(%{cols: cols}) when cols == %{}, do: ""
-  defp make_cols(%{cols: cols}) do
+  defp make_cols(%{cols: cols}, _) when cols == %{}, do: ""
+  defp make_cols(%{cols: cols}, wci) do
     [
       "<cols>",
       Map.to_list(cols)
@@ -292,6 +299,7 @@ defmodule Elixlsx.XMLTemplates do
         "<col",
         make_col_range(key),
         make_col_width(props),
+        make_col_style(props, wci),
         "/>"
       ]
       end),
@@ -326,7 +334,7 @@ defmodule Elixlsx.XMLTemplates do
     </sheetViews>
     <sheetFormatPr defaultRowHeight="12.8"/>
     """
-    <> make_cols(sheet) <>
+    <> make_cols(sheet, wci) <>
     """
     <sheetData>
     """

--- a/test/sheet_test.exs
+++ b/test/sheet_test.exs
@@ -1,0 +1,22 @@
+defmodule Elixlsx.SheetTest do
+  use ExUnit.Case, async: false
+  use ExCheck
+  
+  alias Elixlsx.Sheet
+  
+  property :sheet_name do
+    for_all x in binary() do
+      Sheet.with_name(x).name == x
+    end
+  end
+  
+  property :sheet_cols do
+    for_all x in choose(65,90) do
+      sheet = 
+      %Sheet{}
+      |> Sheet.set_col_width(<<x>>, 10)
+      |> Sheet.set_col(<<x>>, bg_color: "#FFFF00", numfmt: "mmm-yyyy")
+      sheet.cols[x - 64] == %{bg_color: "#FFFF00", numfmt: "mmm-yyyy", width: 10}
+    end
+  end
+end

--- a/test/sheet_test.exs
+++ b/test/sheet_test.exs
@@ -15,8 +15,8 @@ defmodule Elixlsx.SheetTest do
       sheet = 
       %Sheet{}
       |> Sheet.set_col_width(<<x>>, 10)
-      |> Sheet.set_col(<<x>>, bg_color: "#FFFF00", numfmt: "mmm-yyyy")
-      sheet.cols[x - 64] == %{bg_color: "#FFFF00", numfmt: "mmm-yyyy", width: 10}
+      |> Sheet.set_col(<<x>>, bg_color: "#FFFF00", num_format: "mmm-yyyy")
+      sheet.cols[x - 64] == %{bg_color: "#FFFF00", num_format: "mmm-yyyy", width: 10}
     end
   end
 end

--- a/test/xml_templates_test.exs
+++ b/test/xml_templates_test.exs
@@ -1,26 +1,25 @@
 defmodule Elixlsx.XMLTemplatesTest do
   use ExUnit.Case
 
-  alias Elixlsx.Compiler.WorkbookCompInfo
-  alias Elixlsx.Sheet
-  alias Elixlsx.XMLTemplates
+  alias Elixlsx.{Compiler, Compiler.WorkbookCompInfo, Sheet, Workbook, XMLTemplates}
 
   describe("make_sheet") do
     setup do
-      [sheet: Sheet.with_name("Sheet1"), wci: %WorkbookCompInfo{}]
+      [sheet: Sheet.with_name("Sheet1"), wci: %WorkbookCompInfo{}, workbook: %Workbook{}]
     end
 
     test "with default values", %{sheet: sheet, wci: wci} do
       assert XMLTemplates.make_sheet(sheet, wci) =~ "</worksheet>"
     end
 
-    test "with column widths set", %{sheet: sheet, wci: wci} do
-      xml = sheet
+    test "with column attrs set", %{sheet: sheet, workbook: workbook} do
+      sheet = sheet
       |> Sheet.set_col_width("A", 10)
-      |> Sheet.set_col_width("B", 12)
-      |> XMLTemplates.make_sheet(wci)
+      |> Sheet.set_col("B", bg_color: "#FFFF00", num_format: "mmm-yyyy", width: 12)
+      wci = Compiler.make_workbook_comp_info(Workbook.insert_sheet(workbook, sheet))
+      xml = XMLTemplates.make_sheet(sheet, wci)
       assert xml =~ "<col min=\"1\" max=\"1\" width=\"10\" customWidth=\"1\"/>"
-      assert xml =~ "<col min=\"2\" max=\"2\" width=\"12\" customWidth=\"1\"/>"
+      assert xml =~ "<col min=\"2\" max=\"2\" width=\"12\" customWidth=\"1\" style=\"1\"/>"
     end
   end
 end

--- a/test/xml_templates_test.exs
+++ b/test/xml_templates_test.exs
@@ -1,0 +1,26 @@
+defmodule Elixlsx.XMLTemplatesTest do
+  use ExUnit.Case
+
+  alias Elixlsx.Compiler.WorkbookCompInfo
+  alias Elixlsx.Sheet
+  alias Elixlsx.XMLTemplates
+
+  describe("make_sheet") do
+    setup do
+      [sheet: Sheet.with_name("Sheet1"), wci: %WorkbookCompInfo{}]
+    end
+
+    test "with default values", %{sheet: sheet, wci: wci} do
+      assert XMLTemplates.make_sheet(sheet, wci) =~ "</worksheet>"
+    end
+
+    test "with column widths set", %{sheet: sheet, wci: wci} do
+      xml = sheet
+      |> Sheet.set_col_width("A", 10)
+      |> Sheet.set_col_width("B", 12)
+      |> XMLTemplates.make_sheet(wci)
+      assert xml =~ "<col min=\"1\" max=\"1\" width=\"10\" customWidth=\"1\"/>"
+      assert xml =~ "<col min=\"2\" max=\"2\" width=\"12\" customWidth=\"1\"/>"
+    end
+  end
+end


### PR DESCRIPTION
This PR replaces the `sheet.col_widths` field with a `cols` field. Each value in `cols` is a map, which can include multiple attributes for a column, including width, bg_color, num_format etc. The compiler saves column styles in the same way that cell styles are saved, and the relevant style id is included in the xml output for each column. The creation and writing of a file, with only the width set on a column, runs at the same speed as before this PR.

Fixes: https://github.com/xou/elixlsx/issues/48
