### PR TITLE
allow values to be present in merge_cells array in Sheet type

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -24,7 +24,7 @@ defmodule Elixlsx.Sheet do
     row_heights: %{pos_integer => number},
     group_cols: list(rowcol_group),
     group_rows: list(rowcol_group),
-    merge_cells: [],
+    merge_cells: [{String.t, String.t}],
     pane_freeze: {number, number} | nil,
     show_grid_lines: boolean()
   }


### PR DESCRIPTION
When using Dialyzer to check code that depends on elixlsx, we noticed that the type checker fails if you include values in the `merge_cells` parameter of a new `%Sheet{}`. It looks like the `merge_cells` input is expecting `[]`, meaning an empty array, so any included params will throw an error. 

This PR will allow a user to pass tuples of cells to merge as demonstrated in the `example.exs` file, or an empty array if they do not supply a `merge_cells` param, and not fail Dialyzer type checking either way. 

Thanks for the great XLS package!