### PR TITLE
Improve sheet name validation

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -103,10 +103,23 @@ defmodule Elixlsx.XMLTemplates do
   ### xl/workbook.xml
   @spec make_xl_workbook_xml_sheet_entry({Sheet.t(), SheetCompInfo.t()}) :: String.t()
   def make_xl_workbook_xml_sheet_entry({sheet_info, sheet_comp_info}) do
+    if sheet_info.name == "" do
+      raise %ArgumentError{
+        message: "The sheet name cannot be blank."
+      }
+    end
+
     if String.length(sheet_info.name) > 31 do
       raise %ArgumentError{
         message:
           "The sheet name '#{sheet_info.name}' is too long. Maximum 31 chars allowed for name."
+      }
+    end
+
+    if String.contains?(sheet_info.name, ~W(: \ / ? * [ ])) do
+      raise %ArgumentError{
+        message:
+          "The sheet name '#{sheet_info.name}' contains following invalid characters: : \ / ? * [ ])"
       }
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,16 @@ defmodule Elixlsx.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :elixlsx,
-     version: "0.4.2",
-     elixir: "~> 1.3",
-     package: package(),
-     description: "a writer for XLSX spreadsheet files",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :elixlsx,
+      version: "0.4.2",
+      elixir: "~> 1.3",
+      package: package(),
+      description: "a writer for XLSX spreadsheet files",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   def application do

--- a/test/elixlsx_test.exs
+++ b/test/elixlsx_test.exs
@@ -1,8 +1,13 @@
 defmodule ElixlsxTest do
   require Record
-  Record.defrecord :xmlAttribute, Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
-  Record.defrecord :xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
-  Record.defrecord :xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
+
+  Record.defrecord(
+    :xmlAttribute,
+    Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  Record.defrecord(:xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl"))
+  Record.defrecord(:xmlText, Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl"))
 
   use ExUnit.Case
   doctest Elixlsx
@@ -24,48 +29,51 @@ defmodule ElixlsxTest do
   end
 
   defp xml_inner_strings(xml, path) do
-    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
+    {xmerl, []} = :xmerl_scan.string(String.to_charlist(xml))
 
     Enum.map(
       xpath(xmerl, path),
-      fn(element) ->
-        Enum.reduce(xmlElement(element, :content), "", fn(text, acc) ->
+      fn element ->
+        Enum.reduce(xmlElement(element, :content), "", fn text, acc ->
           acc <> to_text(text)
         end)
       end
     )
   end
 
-  defp to_text xml_text do
+  defp to_text(xml_text) do
     xmlText(value: value) = xml_text
-    to_string value
+    to_string(value)
   end
 
   test "basic StringDB functionality" do
-    sdb = (%StringDB{}
-            |> StringDB.register_string("Hello")
-            |> StringDB.register_string("World")
-            |> StringDB.register_string("Hello"))
+    sdb =
+      %StringDB{}
+      |> StringDB.register_string("Hello")
+      |> StringDB.register_string("World")
+      |> StringDB.register_string("Hello")
 
-    xml = XMLTemplates.make_xl_shared_strings(StringDB.sorted_id_string_tuples sdb)
+    xml = XMLTemplates.make_xl_shared_strings(StringDB.sorted_id_string_tuples(sdb))
 
     assert xml_inner_strings(xml, '/sst/si/t') == ["Hello", "World"]
   end
 
   test "xml escaping StringDB functionality" do
-    sdb = (%StringDB{}
-            |> StringDB.register_string("Hello World & Goodbye Cruel World"))
+    sdb =
+      %StringDB{}
+      |> StringDB.register_string("Hello World & Goodbye Cruel World")
 
-    xml = XMLTemplates.make_xl_shared_strings(StringDB.sorted_id_string_tuples sdb)
+    xml = XMLTemplates.make_xl_shared_strings(StringDB.sorted_id_string_tuples(sdb))
 
     assert xml_inner_strings(xml, '/sst/si/t') == ["Hello World & Goodbye Cruel World"]
   end
 
   test "font color" do
-    xml = Font.from_props(color: "#012345") |>
-    Font.get_stylexml_entry
+    xml =
+      Font.from_props(color: "#012345")
+      |> Font.get_stylexml_entry()
 
-    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
+    {xmerl, []} = :xmerl_scan.string(String.to_charlist(xml))
 
     [color] = :xmerl_xpath.string('/font/color/@rgb', xmerl)
 
@@ -73,10 +81,11 @@ defmodule ElixlsxTest do
   end
 
   test "font name" do
-    xml = Font.from_props(font: "Arial") |>
-    Font.get_stylexml_entry
+    xml =
+      Font.from_props(font: "Arial")
+      |> Font.get_stylexml_entry()
 
-    {xmerl, []} = :xmerl_scan.string String.to_charlist(xml)
+    {xmerl, []} = :xmerl_scan.string(String.to_charlist(xml))
 
     [name] = :xmerl_xpath.string('/font/name/@val', xmerl)
 
@@ -85,9 +94,12 @@ defmodule ElixlsxTest do
 
   test "too long sheet name" do
     sheet1 = Sheet.with_name("This is a very looong sheet name")
-    assert_raise ArgumentError, ~r/The sheet name .* is too long. Maximum 31 chars allowed for name./, fn ->
-      %Workbook{sheets: [sheet1]}
-      |> Elixlsx.write_to("test.xlsx")
-    end
+
+    assert_raise ArgumentError,
+                 ~r/The sheet name .* is too long. Maximum 31 chars allowed for name./,
+                 fn ->
+                   %Workbook{sheets: [sheet1]}
+                   |> Elixlsx.write_to("test.xlsx")
+                 end
   end
 end

--- a/test/elixlsx_test.exs
+++ b/test/elixlsx_test.exs
@@ -92,6 +92,15 @@ defmodule ElixlsxTest do
     assert xmlAttribute(name, :value) == 'Arial'
   end
 
+  test "blank sheet name" do
+    sheet1 = Sheet.with_name("")
+
+    assert_raise ArgumentError, "The sheet name cannot be blank.", fn ->
+      %Workbook{sheets: [sheet1]}
+      |> Elixlsx.write_to("test.xlsx")
+    end
+  end
+
   test "too long sheet name" do
     sheet1 = Sheet.with_name("This is a very looong sheet name")
 
@@ -101,5 +110,20 @@ defmodule ElixlsxTest do
                    %Workbook{sheets: [sheet1]}
                    |> Elixlsx.write_to("test.xlsx")
                  end
+  end
+
+  test "invalid chars in sheet name" do
+    sheet_names = ~W(: \ / ? * [ ])
+
+    Enum.each(sheet_names, fn name ->
+      sheet1 = Sheet.with_name(name)
+
+      assert_raise ArgumentError,
+                   ~r/The sheet name .* contains following invalid characters:/,
+                   fn ->
+                     %Workbook{sheets: [sheet1]}
+                     |> Elixlsx.write_to("test.xlsx")
+                   end
+    end)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExCheck.start
+ExCheck.start()
 ExUnit.start()

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -11,5 +11,4 @@ defmodule ExCheck.UtilTest do
       end
     end
   end
-  
 end


### PR DESCRIPTION
Add blank and invalid characters validation in sheet name.

And I found the length of sheet name validation using `String.length/1` currently. This will fail when non-ASCII characters contain in sheet name because it counting by Unicode graphemes but not byte size. And I found the length of sheet name in Excel 16.16.14 on Mac seems to calculate by counting UCS-2 points or this in Elixir:
```Elixir
"😂" |> :unicode.characters_to_binary(:utf8, :utf16) |> byte_size() |> div(2)
```

Should I also fix the length validation?