### PR TITLE
adds preserve spaces XML attribute

### DIFF
--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -541,7 +541,7 @@ defmodule Elixlsx.XMLTemplates do
     """ <>
       Enum.map_join(stringlist, fn {_, value} ->
         # the only two characters that *must* be replaced for safe XML encoding are & and <:
-        "<si><t>#{minimal_xml_text_escape(value)}</t></si>"
+        "<si><t xml:space=\"preserve\">#{minimal_xml_text_escape value}</t></si>"
       end) <> "</sst>"
   end
 

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -541,7 +541,7 @@ defmodule Elixlsx.XMLTemplates do
     """ <>
       Enum.map_join(stringlist, fn {_, value} ->
         # the only two characters that *must* be replaced for safe XML encoding are & and <:
-        "<si><t xml:space=\"preserve\">#{minimal_xml_text_escape value}</t></si>"
+        "<si><t xml:space=\"preserve\">#{minimal_xml_text_escape(value)}</t></si>"
       end) <> "</sst>"
   end
 


### PR DESCRIPTION
Currently if you try to add leading whitespace to a cell it gets stripped out. I've modified the code to add the `xml:space="preserve"` attribute to the strings sharedStrings database which addresses this.