### PR TITLE
Add cells validators

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -42,6 +42,11 @@ sheet1 =
   |> Sheet.set_cell("E6", {:formula, "SUM(E1:E5)", value: 15.70}, num_format: "0.00", bold: true)
   |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
   |> Sheet.set_col_width("F", 18.0)
+  # Validations
+  |> Sheet.set_cell("G1", "dog")
+  |> Sheet.set_cell("G2", "cat")
+  |> Sheet.set_cell("G3", "cow")
+  |> Sheet.add_validation("G1", "G10", ["dog", "cat", "cow"])
 
 workbook = %Workbook{sheets: [sheet1]}
 

--- a/example.exs
+++ b/example.exs
@@ -42,11 +42,11 @@ sheet1 =
   |> Sheet.set_cell("E6", {:formula, "SUM(E1:E5)", value: 15.70}, num_format: "0.00", bold: true)
   |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
   |> Sheet.set_col_width("F", 18.0)
-  # Validations
-  |> Sheet.set_cell("G1", "dog")
-  |> Sheet.set_cell("G2", "cat")
-  |> Sheet.set_cell("G3", "cow")
-  |> Sheet.add_validation("G1", "G10", ["dog", "cat", "cow"])
+  # Data validations
+  |> Sheet.set_cell("A1", "dog")
+  |> Sheet.set_cell("A2", "cat")
+  |> Sheet.set_cell("A3", "cow")
+  |> Sheet.add_data_validations("A1", "A10", ["dog", "cat", "cow"])
 
 workbook = %Workbook{sheets: [sheet1]}
 

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -27,6 +27,7 @@ defmodule Elixlsx.Sheet do
             group_cols: [],
             group_rows: [],
             merge_cells: [],
+            validations: [],
             pane_freeze: nil,
             show_grid_lines: true
 
@@ -39,7 +40,8 @@ defmodule Elixlsx.Sheet do
           group_rows: list(rowcol_group),
           merge_cells: [{String.t(), String.t()}],
           pane_freeze: {number, number} | nil,
-          show_grid_lines: boolean()
+          show_grid_lines: boolean(),
+          validations: list({String.t(), String.t(), list(String.t())})
         }
   @type rowcol_group :: Range.t() | {Range.t(), opts :: keyword}
 
@@ -218,5 +220,10 @@ defmodule Elixlsx.Sheet do
   """
   def remove_pane_freeze(sheet) do
     %{sheet | pane_freeze: nil}
+  end
+
+  @spec add_validation(Sheet.t(), String.t(), String.t(), list(String.t())) :: Sheet.t()
+  def add_validation(sheet, start_cell, end_cell, values) do
+    %{sheet | validations: [{start_cell, end_cell, values} | sheet.validations]}
   end
 end

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -27,9 +27,9 @@ defmodule Elixlsx.Sheet do
             group_cols: [],
             group_rows: [],
             merge_cells: [],
-            validations: [],
             pane_freeze: nil,
-            show_grid_lines: true
+            show_grid_lines: true,
+            data_validations: []
 
   @type t :: %Sheet{
           name: String.t(),
@@ -41,7 +41,7 @@ defmodule Elixlsx.Sheet do
           merge_cells: [{String.t(), String.t()}],
           pane_freeze: {number, number} | nil,
           show_grid_lines: boolean(),
-          validations: list({String.t(), String.t(), list(String.t())})
+          data_validations: list({String.t(), String.t(), list(String.t())})
         }
   @type rowcol_group :: Range.t() | {Range.t(), opts :: keyword}
 
@@ -222,8 +222,8 @@ defmodule Elixlsx.Sheet do
     %{sheet | pane_freeze: nil}
   end
 
-  @spec add_validation(Sheet.t(), String.t(), String.t(), list(String.t())) :: Sheet.t()
-  def add_validation(sheet, start_cell, end_cell, values) do
-    %{sheet | validations: [{start_cell, end_cell, values} | sheet.validations]}
+  @spec add_data_validations(Sheet.t(), String.t(), String.t(), list(String.t())) :: Sheet.t()
+  def add_data_validations(sheet, start_cell, end_cell, values) do
+    %{sheet | data_validations: [{start_cell, end_cell, values} | sheet.data_validations]}
   end
 end

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -288,19 +288,19 @@ defmodule Elixlsx.XMLTemplates do
     updated_row
   end
 
-  defp make_validations([]) do
+  defp make_data_validations([]) do
     ""
   end
 
-  defp make_validations(validations) do
+  defp make_data_validations(data_validations) do
     """
-    <dataValidations count="#{Enum.count(validations)}">
-      #{Enum.map(validations, &make_validation/1)}
+    <dataValidations count="#{Enum.count(data_validations)}">
+      #{Enum.map(data_validations, &make_data_validation/1)}
     </dataValidations>
     """
   end
 
-  defp make_validation({start_cell, end_cell, values}) do
+  defp make_data_validation({start_cell, end_cell, values}) do
     joined_values =
       values
       |> Enum.join(",")
@@ -501,7 +501,7 @@ defmodule Elixlsx.XMLTemplates do
       </sheetData>
       """ <>
       xl_merge_cells(sheet.merge_cells) <>
-      make_validations(sheet.validations) <>
+      make_data_validations(sheet.data_validations) <>
       """
       <pageMargins left="0.75" right="0.75" top="1" bottom="1.0" header="0.5" footer="0.5"/>
       </worksheet>

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -288,6 +288,29 @@ defmodule Elixlsx.XMLTemplates do
     updated_row
   end
 
+  defp make_validations([]) do
+    ""
+  end
+
+  defp make_validations(validations) do
+    """
+    <dataValidations count="#{Enum.count(validations)}">
+      #{Enum.map(validations, &make_validation/1)}
+    </dataValidations>
+    """
+  end
+
+  defp make_validation({start_cell, end_cell, values}) do
+    """
+    <dataValidation allowBlank="true" operator="equal" showDropDown="false" showErrorMessage="true" showInputMessage="false" sqref="#{
+      start_cell
+    }:#{end_cell}" type="list">
+      <formula1>"#{Enum.join(values, ",")}"</formula1>
+      <formula2>0</formula2>
+    </dataValidation>
+    """
+  end
+
   defp xl_merge_cells([]) do
     ""
   end
@@ -472,6 +495,7 @@ defmodule Elixlsx.XMLTemplates do
       </sheetData>
       """ <>
       xl_merge_cells(sheet.merge_cells) <>
+      make_validations(sheet.validations) <>
       """
       <pageMargins left="0.75" right="0.75" top="1" bottom="1.0" header="0.5" footer="0.5"/>
       </worksheet>

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -301,12 +301,18 @@ defmodule Elixlsx.XMLTemplates do
   end
 
   defp make_validation({start_cell, end_cell, values}) do
+    joined_values =
+      values
+      |> Enum.join(",")
+      |> String.codepoints()
+      |> Enum.chunk_every(255)
+      |> Enum.join("&quot;&amp;&quot;")
+
     """
-    <dataValidation allowBlank="true" operator="equal" showDropDown="false" showErrorMessage="true" showInputMessage="false" sqref="#{
-      start_cell
-    }:#{end_cell}" type="list">
-      <formula1>"#{Enum.join(values, ",")}"</formula1>
-      <formula2>0</formula2>
+    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{
+      end_cell
+    }">
+      <formula1>&quot;#{joined_values}&quot;</formula1>
     </dataValidation>
     """
   end


### PR DESCRIPTION
## Motivation

This PR adds support for the [validations dropdown feature from Excel](https://support.microsoft.com/en-us/office/apply-data-validation-to-cells-29fecbcc-d1b9-42c1-9d76-eff3ce5f7249). 

More info about `DataValidation` tag can be found [here](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.datavalidation?view=openxml-2.8.1).

## Screenshots

![image](https://user-images.githubusercontent.com/5060004/111222144-308eac80-85ba-11eb-97e6-ed9ae5178ba8.png)

![image](https://user-images.githubusercontent.com/5060004/111222269-5f0c8780-85ba-11eb-9193-091929e482b1.png)
