### PR TITLE
namespace xml module

### DIFF
--- a/lib/elixlsx/compiler.ex
+++ b/lib/elixlsx/compiler.ex
@@ -3,6 +3,7 @@ defmodule Elixlsx.Compiler do
   alias Elixlsx.Compiler.SheetCompInfo
   alias Elixlsx.Compiler.CellStyleDB
   alias Elixlsx.Compiler.StringDB
+  alias Elixlsx.XML
   alias Elixlsx.Sheet
 
   @doc ~S"""

--- a/lib/elixlsx/compiler/string_db.ex
+++ b/lib/elixlsx/compiler/string_db.ex
@@ -1,5 +1,6 @@
 defmodule Elixlsx.Compiler.StringDB do
   alias Elixlsx.Compiler.StringDB
+  alias Elixlsx.XML
 
   @moduledoc ~S"""
   Strings in XLSX can be stored in a sharedStrings.xml file and be looked up

--- a/lib/elixlsx/style/num_fmt.ex
+++ b/lib/elixlsx/style/num_fmt.ex
@@ -1,4 +1,5 @@
 defmodule Elixlsx.Style.NumFmt do
+  alias Elixlsx.XML
   alias __MODULE__
 
   defstruct format: nil

--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -1,4 +1,5 @@
 defmodule Elixlsx.Util do
+  alias Elixlsx.XML
   @col_alphabet Enum.to_list(?A..?Z)
 
   @doc ~S"""

--- a/lib/elixlsx/xml.ex
+++ b/lib/elixlsx/xml.ex
@@ -1,4 +1,4 @@
-defmodule XML do
+defmodule Elixlsx.XML do
   @xml_chars_block_1 [9, 10, 13]
   @xml_chars_block_2 32..55_295
   @xml_chars_block_3 57_344..65_533

--- a/test/xml_test.exs
+++ b/test/xml_test.exs
@@ -1,6 +1,8 @@
 defmodule XMLTest do
   use ExUnit.Case
 
+  alias Elixlsx.XML
+
   test "valid? allows normal string" do
     assert XML.valid?("Hello World & Goodbye Cruel World")
   end


### PR DESCRIPTION
Per this issue: #107 

We've been unable to update elixlsx due to the top-level XML module introduced in #86.
This pr seeks to namespace that module to match the usual practice and adds aliases as necessary 

