### PR TITLE
Add cells validators

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -42,6 +42,11 @@ sheet1 =
   |> Sheet.set_cell("E6", {:formula, "SUM(E1:E5)", value: 15.70}, num_format: "0.00", bold: true)
   |> Sheet.set_cell("F1", {:formula, "NOW()"}, num_format: "yyyy-mm-dd hh:MM:ss")
   |> Sheet.set_col_width("F", 18.0)
+  # Data validations
+  |> Sheet.set_cell("A1", "dog")
+  |> Sheet.set_cell("A2", "cat")
+  |> Sheet.set_cell("A3", "cow")
+  |> Sheet.add_data_validations("A1", "A10", ["dog", "cat", "cow"])
 
 workbook = %Workbook{sheets: [sheet1]}
 

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -28,7 +28,8 @@ defmodule Elixlsx.Sheet do
             group_rows: [],
             merge_cells: [],
             pane_freeze: nil,
-            show_grid_lines: true
+            show_grid_lines: true,
+            data_validations: []
 
   @type t :: %Sheet{
           name: String.t(),
@@ -39,7 +40,8 @@ defmodule Elixlsx.Sheet do
           group_rows: list(rowcol_group),
           merge_cells: [{String.t(), String.t()}],
           pane_freeze: {number, number} | nil,
-          show_grid_lines: boolean()
+          show_grid_lines: boolean(),
+          data_validations: list({String.t(), String.t(), list(String.t())})
         }
   @type rowcol_group :: Range.t() | {Range.t(), opts :: keyword}
 
@@ -218,5 +220,10 @@ defmodule Elixlsx.Sheet do
   """
   def remove_pane_freeze(sheet) do
     %{sheet | pane_freeze: nil}
+  end
+  
+  @spec add_data_validations(Sheet.t(), String.t(), String.t(), list(String.t())) :: Sheet.t()
+  def add_data_validations(sheet, start_cell, end_cell, values) do
+    %{sheet | data_validations: [{start_cell, end_cell, values} | sheet.data_validations]}
   end
 end

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -288,6 +288,35 @@ defmodule Elixlsx.XMLTemplates do
     updated_row
   end
 
+  defp make_data_validations([]) do
+    ""
+  end
+
+  defp make_data_validations(data_validations) do
+    """
+    <dataValidations count="#{Enum.count(data_validations)}">
+      #{Enum.map(data_validations, &make_data_validation/1)}
+    </dataValidations>
+    """
+  end
+
+  defp make_data_validation({start_cell, end_cell, values}) do
+    joined_values =
+      values
+      |> Enum.join(",")
+      |> String.codepoints()
+      |> Enum.chunk_every(255)
+      |> Enum.join("&quot;&amp;&quot;")
+
+    """
+    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{
+      end_cell
+    }">
+      <formula1>&quot;#{joined_values}&quot;</formula1>
+    </dataValidation>
+    """
+  end
+
   defp xl_merge_cells([]) do
     ""
   end
@@ -472,6 +501,7 @@ defmodule Elixlsx.XMLTemplates do
       </sheetData>
       """ <>
       xl_merge_cells(sheet.merge_cells) <>
+      make_data_validations(sheet.data_validations) <>
       """
       <pageMargins left="0.75" right="0.75" top="1" bottom="1.0" header="0.5" footer="0.5"/>
       </worksheet>


### PR DESCRIPTION
### Motivation
This PR adds support for the [validations dropdown feature from Excel.](https://support.microsoft.com/en-us/office/apply-data-validation-to-cells-29fecbcc-d1b9-42c1-9d76-eff3ce5f7249)

More info about `DataValidation` tag can be found [here](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.datavalidation?view=openxml-2.8.1).

### Screenshots

![](https://user-images.githubusercontent.com/5060004/111222144-308eac80-85ba-11eb-97e6-ed9ae5178ba8.png)

![](https://user-images.githubusercontent.com/5060004/111222269-5f0c8780-85ba-11eb-9193-091929e482b1.png)