### PR TITLE
Add support for Decimal

### DIFF
--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -175,6 +175,12 @@ defmodule Elixlsx.XMLTemplates do
 
   defp split_into_content_style(cell, _wci), do: {cell, 0, nil}
 
+  if Code.ensure_loaded?(Decimal) do
+    defp get_content_type_value(%Decimal{} = content, _wci) do
+      {"n", Decimal.to_string(content, :normal)}
+    end
+  end
+
   defp get_content_type_value(content, wci) do
     case content do
       {:excelts, num} ->

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -175,7 +175,7 @@ defmodule Elixlsx.XMLTemplates do
 
   defp split_into_content_style(cell, _wci), do: {cell, 0, nil}
 
-  if Code.ensure_loaded?(Decimal) do
+  if Code.ensure_loaded?(Decimal) and function_exported?(Decimal, :to_string, 2) do
     defp get_content_type_value(%Decimal{} = content, _wci) do
       {"n", Decimal.to_string(content, :normal)}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Elixlsx.Mixfile do
 
   defp deps do
     [
+      {:decimal, "~> 1.6 or ~> 2.0", optional: true},
       {:excheck, "~> 0.5", only: :test},
       {:triq, "~> 1.0", only: :test},
       {:credo, "~> 0.5", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], [], "hexpm", "4fb7b2f7b04af13cf210b132f8d10db52d4a57d36cb974e8025d7fdb12ca97fc"},
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm", "90bca5180fe64c47343969ad3e32bf1edc18d929689e8c00c810655a7a391427"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},


### PR DESCRIPTION
First of all, thanks for creating this lib :)

I've been working with `Decimal` mostly because `float` _uses the shortest representation according to the algorithm described in "Printing Floating-Point Numbers Quickly and Accurately"_ (quoting the doc https://hexdocs.pm/elixir/Float.html#to_string/1), ie:

```
iex> "#{Float.round(1.1, 2)}"
"1.1"
iex> "#{Decimal.round("1.1", 2)}"
"1.10"
```

Besides this presentation issue, converting `to_string` makes that cell to be a binary which isn't ideal for working with formulas on the sheet.

AFAIK this has been proposed before (https://github.com/xou/elixlsx/pull/43) but it was rejected for 2 reasons: 1) no actual use-case for it, and 2) for adding the `Decimal` lib (looks like that's the main reason). Turns out there's no need to actually add a dependency, we can check if it's loaded at run-time, just like many libs do, eg in [ecto_sql](https://github.com/elixir-ecto/ecto_sql/blob/92a4a5c5030804fe37e20176922da55164868a4e/lib/ecto/adapters/postgres/connection.ex#L1) or [phoenix_live_view](https://github.com/phoenixframework/phoenix_live_view/blob/874af9e8d5474c199bf0feff71a593941530067e/lib/phoenix_live_view/test/dom.ex#L10). I believe that's reasonable so I'd like to propose adding `Decimal` handling yet one more time, considering there's a real use-case to justify adding it and there's no need to add a dependency.

/edit On repo https://github.com/leandrocp/elixlsx_decimal/commits/main you can see an example with and without Decimal