### PR TITLE
Add text rotation style

### DIFF
--- a/example.exs
+++ b/example.exs
@@ -19,7 +19,7 @@ sheet1 =
   # the datetime: true parameter automatically applies conversion to Excels internal format.
   |> Sheet.set_cell("A2", {{2015, 11, 30}, {21, 20, 38}}, datetime: true)
   |> Sheet.set_cell("A3", 1_448_882_362, datetime: true)
-  # datetime: true ouputs date and time, yyyymmdd limits the output to just the date
+  # datetime: true outputs date and time, yyyymmdd limits the output to just the date
   |> Sheet.set_cell("A4", 1_448_882_362, yyyymmdd: true)
   # make some room in the first column, otherwise the date will only show up as ###
   |> Sheet.set_col_width("A", 18.0)

--- a/lib/elixlsx/util.ex
+++ b/lib/elixlsx/util.ex
@@ -224,7 +224,7 @@ defmodule Elixlsx.Util do
     {:excelts, value}
   end
 
-  # Formula's value calculate on opening excel programm.
+  # Formula's value calculate on opening excel program.
   # We don't need to format this here.
   @spec to_excel_datetime({:formula, String.t()}) :: {:formula, String.t()}
   def to_excel_datetime({:formula, value}) do

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -699,7 +699,7 @@ defmodule Elixlsx.XMLTemplates do
   defp validate_text_rotation(255), do: {:ok, 255}
   defp validate_text_rotation(angle) when angle >= 0 and angle <= 180, do: {:ok, angle}
 
-  # Creates an aligment xml tag from font style.
+  # Creates an alignment xml tag from font style.
   @spec make_style_alignment(Font.t()) :: String.t()
   defp make_style_alignment(font) do
     attrs =


### PR DESCRIPTION
# Adding support for text rotation
![Screen Shot 2021-10-15 at 13 01 03](https://user-images.githubusercontent.com/1173279/137477275-18c5b697-1b7f-494d-9fdc-c847abea9ffc.png)

## Usage
```Elixir
# Text rotation.
sheet7 =
  %Sheet{name: "Text rotation"}
  |> Sheet.set_cell("A1", "Hello - angle_ccw",  text_rotation: :angle_ccw)
  |> Sheet.set_cell("B1", "Hello - angle_cw",  text_rotation: :angle_cw)
  |> Sheet.set_cell("C1", "Vertical - vertical", text_rotation: :vertical)
  |> Sheet.set_cell("D1", "Hello - rotate_up", text_rotation: :rotate_up)
  |> Sheet.set_cell("E1", "Hello - rotate_down", text_rotation: :rotate_down)
  |> Sheet.set_cell("F1", "Hello - 20", text_rotation: 20)
```

## XML
This adds the `textRotation` xml attribute.
```xml
    <xf numFmtId="0" fontId="0" fillId="2" borderId="1" xfId="0" applyFill="1" applyBorder="1" applyAlignment="1">
      <alignment vertical="center" textRotation="180"/>
    </xf>
```

