### PR TITLE
support formulas for csv export

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -77,6 +77,7 @@ defmodule Elixlsx.Sheet do
 
         case content do
           nil -> ""
+          {:formula, val} -> String.Chars.to_string(val)
           _ -> to_string(content)
         end
       end)

--- a/test/elixlsx_test.exs
+++ b/test/elixlsx_test.exs
@@ -126,4 +126,26 @@ defmodule ElixlsxTest do
                    end
     end)
   end
+
+  test "test csv can export function value" do
+    csv = Sheet.with_name("A name")
+    |> Sheet.set_at(
+         0,
+         0,
+         {:formula, "foo"}
+       )
+    |> Sheet.set_at(
+         0,
+         1,
+         {:formula, "=HYPERLINK(\"https://www.google.com\", \"Go To Google\")"}
+       )
+    |> Sheet.set_at(
+         0,
+         2,
+         {:formula, "bar"}
+       )
+    |> Sheet.to_csv_string()
+
+    assert csv == "foo,=HYPERLINK(\"https://www.google.com\", \"Go To Google\"),bar"
+  end
 end


### PR DESCRIPTION
This adds support for formulas in csv export.  Please note that the csv export does not currently escape commas, etc.  You may consider a csv lib for this but fix at least prevents the following:  

```(Protocol.UndefinedError) protocol String.Chars not implemented for {:formula, "foo"} of type Tuple```  