### PR TITLE
Large tables generation speedup

### DIFF
--- a/lib/elixlsx/compiler.ex
+++ b/lib/elixlsx/compiler.ex
@@ -61,8 +61,8 @@ defmodule Elixlsx.Compiler do
 
   @spec compinfo_from_rows(WorkbookCompInfo.t(), list(list(any()))) :: WorkbookCompInfo.t()
   def compinfo_from_rows(wci, rows) do
-    List.foldl(rows, wci, fn cols, wci ->
-      List.foldl(cols, wci, fn cell, wci ->
+    Enum.reduce(rows, wci, fn {_row, cols}, wci ->
+      Enum.reduce(cols, wci, fn {_col, cell}, wci ->
         compinfo_cell_pass(wci, cell)
       end)
     end)
@@ -71,7 +71,7 @@ defmodule Elixlsx.Compiler do
   @spec compinfo_from_sheets(WorkbookCompInfo.t(), list(Sheet.t())) :: WorkbookCompInfo.t()
   def compinfo_from_sheets(wci, sheets) do
     List.foldl(sheets, wci, fn sheet, wci ->
-      compinfo_from_rows(wci, sheet.rows)
+      compinfo_from_rows(wci, sheet.cells)
     end)
   end
 

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -85,17 +85,6 @@ defmodule Elixlsx.Sheet do
         end
       end)
     end)
-
-    # Enum.map_join(sheet.rows, "\n", fn row ->
-    #   Enum.map_join(row, ",", fn cell ->
-    #     {content, _} = split_cell_content_props(cell)
-
-    #     case content do
-    #       nil -> ""
-    #       _ -> to_string(content)
-    #     end
-    #   end)
-    # end)
   end
 
   @spec set_cell(Sheet.t(), String.t(), any(), Keyword.t()) :: Sheet.t()

--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -21,7 +21,7 @@ defmodule Elixlsx.Sheet do
   cell. See `Font.from_props/1` for a list of options.
   """
   defstruct name: "",
-            rows: [],
+            cells: %{},
             col_widths: %{},
             row_heights: %{},
             group_cols: [],
@@ -33,7 +33,7 @@ defmodule Elixlsx.Sheet do
 
   @type t :: %Sheet{
           name: String.t(),
-          rows: list(list(any())),
+          cells: %{integer() => %{integer() => any()}},
           col_widths: %{pos_integer => number},
           row_heights: %{pos_integer => number},
           group_cols: list(rowcol_group),
@@ -71,9 +71,13 @@ defmodule Elixlsx.Sheet do
   This is mainly used for doctests and does not generate valid CSV (yet).
   """
   def to_csv_string(sheet) do
-    Enum.map_join(sheet.rows, "\n", fn row ->
-      Enum.map_join(row, ",", fn cell ->
-        {content, _} = split_cell_content_props(cell)
+    last_row_idx = Map.keys(sheet.cells) |> Enum.max()
+
+    Enum.map_join(0..last_row_idx, "\n", fn row ->
+      last_col_idx = Map.keys(sheet.cells[row]) |> Enum.max()
+
+      Enum.map_join(0..last_col_idx, ",", fn col ->
+        {content, _} = split_cell_content_props(sheet.cells[row][col])
 
         case content do
           nil -> ""
@@ -81,6 +85,17 @@ defmodule Elixlsx.Sheet do
         end
       end)
     end)
+
+    # Enum.map_join(sheet.rows, "\n", fn row ->
+    #   Enum.map_join(row, ",", fn cell ->
+    #     {content, _} = split_cell_content_props(cell)
+
+    #     case content do
+    #       nil -> ""
+    #       _ -> to_string(content)
+    #     end
+    #   end)
+    # end)
   end
 
   @spec set_cell(Sheet.t(), String.t(), any(), Keyword.t()) :: Sheet.t()
@@ -119,30 +134,7 @@ defmodule Elixlsx.Sheet do
   """
   def set_at(sheet, rowidx, colidx, content, opts \\ [])
       when is_number(rowidx) and is_number(colidx) do
-    cond do
-      length(sheet.rows) <= rowidx ->
-        # append new rows, call self again with new sheet
-        n_new_rows = rowidx - length(sheet.rows)
-        new_rows = 0..n_new_rows |> Enum.map(fn _ -> [] end)
-
-        update_in(sheet.rows, &(&1 ++ new_rows))
-        |> set_at(rowidx, colidx, content, opts)
-
-      length(Enum.at(sheet.rows, rowidx)) <= colidx ->
-        n_new_cols = colidx - length(Enum.at(sheet.rows, rowidx))
-        new_cols = 0..n_new_cols |> Enum.map(fn _ -> nil end)
-        new_row = Enum.at(sheet.rows, rowidx) ++ new_cols
-
-        update_in(sheet.rows, &List.replace_at(&1, rowidx, new_row))
-        |> set_at(rowidx, colidx, content, opts)
-
-      true ->
-        update_in(sheet.rows, fn rows ->
-          List.update_at(rows, rowidx, fn cols ->
-            List.replace_at(cols, colidx, [content | opts])
-          end)
-        end)
-    end
+    put_in(sheet, [Access.key!(:cells), Access.key(rowidx, %{}), colidx], [content | opts])
   end
 
   @spec set_col_width(Sheet.t(), String.t(), number) :: Sheet.t()

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -90,9 +90,7 @@ defmodule Elixlsx.XMLTemplates do
   def make_xl_rel_sheet(sheet_comp_info) do
     # I'd love to use string interpolation here, but unfortunately """< is heredoc notation, so i have to use
     # string concatenation or escape all the quotes. Choosing the first.
-    "<Relationship Id=\"#{sheet_comp_info.rId}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/#{
-      sheet_comp_info.filename
-    }\"/>"
+    "<Relationship Id=\"#{sheet_comp_info.rId}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/#{sheet_comp_info.filename}\"/>"
   end
 
   @spec make_xl_rel_sheets(nonempty_list(SheetCompInfo.t())) :: String.t()
@@ -124,9 +122,7 @@ defmodule Elixlsx.XMLTemplates do
     end
 
     """
-    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{
-      sheet_comp_info.rId
-    }"/>
+    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{sheet_comp_info.rId}"/>
     """
   end
 
@@ -216,13 +212,16 @@ defmodule Elixlsx.XMLTemplates do
 
   # TODO i know now about string interpolation, i should probably clean this up. ;)
   defp xl_sheet_cols(row, rowidx, wci) do
-    {updated_row, _id} =
-      row
-      |> List.foldl({"", 1}, fn cell, {acc, colidx} ->
+    updated_row =
+      Map.keys(row)
+      |> Enum.sort()
+      |> Enum.map(&(&1 + 1))
+      |> Enum.reduce("", fn colidx, acc ->
+        cell = row[colidx - 1]
         {content, styleID, cellstyle} = split_into_content_style(cell, wci)
 
         if is_nil(content) do
-          {acc, colidx + 1}
+          acc
         else
           content =
             if CellStyle.is_date?(cellstyle) do
@@ -275,13 +274,14 @@ defmodule Elixlsx.XMLTemplates do
               type ->
                 """
                 <c r="#{U.to_excel_coords(rowidx, colidx)}"
+
                 s="#{styleID}" t="#{type}">
                 <v>#{content_value}</v>
                 </c>
                 """
             end
 
-          {acc <> cell_xml, colidx + 1}
+          acc <> cell_xml
         end
       end)
 
@@ -302,9 +302,7 @@ defmodule Elixlsx.XMLTemplates do
 
   defp make_data_validation({start_cell, end_cell, values}) when is_bitstring(values) do
     """
-    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{
-      end_cell
-    }">
+    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{end_cell}">
       <formula1>#{values}</formula1>
     </dataValidation>
     """
@@ -319,9 +317,7 @@ defmodule Elixlsx.XMLTemplates do
       |> Enum.join("&quot;&amp;&quot;")
 
     """
-    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{
-      end_cell
-    }">
+    <dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="#{start_cell}:#{end_cell}">
       <formula1>&quot;#{joined_values}&quot;</formula1>
     </dataValidation>
     """
@@ -334,32 +330,31 @@ defmodule Elixlsx.XMLTemplates do
   defp xl_merge_cells(merge_cells) do
     """
     <mergeCells count="#{Enum.count(merge_cells)}">
-      #{
-      Enum.map(merge_cells, fn {fromCell, toCell} ->
-        "<mergeCell ref=\"#{fromCell}:#{toCell}\"/>"
-      end)
-    }
+      #{Enum.map(merge_cells, fn {fromCell, toCell} -> "<mergeCell ref=\"#{fromCell}:#{toCell}\"/>" end)}
     </mergeCells>
     """
   end
 
-  defp xl_sheet_rows(data, row_heights, grouping_info, wci) do
+  defp xl_sheet_rows(cells, row_heights, grouping_info, wci) do
+    max_row = Map.keys(cells) |> Enum.max()
+
     rows =
-      Enum.zip(data, 1..length(data))
-      |> Enum.map_join(fn {row, rowidx} ->
+      Map.keys(cells)
+      |> Enum.sort()
+      |> Enum.map_join(fn rowidx ->
+        row = cells[rowidx]
+
         """
-        <row r="#{rowidx}" #{get_row_height_attr(row_heights, rowidx)}#{
-          get_row_grouping_attr(grouping_info, rowidx)
-        }>
-          #{xl_sheet_cols(row, rowidx, wci)}
+        <row r="#{rowidx + 1}" #{get_row_height_attr(row_heights, rowidx + 1)}#{get_row_grouping_attr(grouping_info, rowidx + 1)}>
+          #{xl_sheet_cols(row, rowidx + 1, wci)}
         </row>
         """
       end)
 
-    if (length(data) + 1) in grouping_info.collapsed_idxs do
+    if (max_row + 1) in grouping_info.collapsed_idxs do
       rows <>
         """
-        <row r="#{length(data) + 1}" collapsed="1"></row>
+        <row r="#{max_row + 1}" collapsed="1"></row>
         """
     else
       rows
@@ -506,7 +501,7 @@ defmodule Elixlsx.XMLTemplates do
       """
       <sheetData>
       """ <>
-      xl_sheet_rows(sheet.rows, sheet.row_heights, grouping_info, wci) <>
+      xl_sheet_rows(sheet.cells, sheet.row_heights, grouping_info, wci) <>
       ~S"""
       </sheetData>
       """ <>
@@ -554,9 +549,7 @@ defmodule Elixlsx.XMLTemplates do
           top_left_cell = U.to_excel_coords(row_idx + 1, col_idx + 1)
 
           {"pane=\"#{pane}\"",
-           "<pane xSplit=\"#{col_idx}\" ySplit=\"#{row_idx}\" topLeftCell=\"#{top_left_cell}\" activePane=\"#{
-             pane
-           }\" state=\"frozen\" />"}
+           "<pane xSplit=\"#{col_idx}\" ySplit=\"#{row_idx}\" topLeftCell=\"#{top_left_cell}\" activePane=\"#{pane}\" state=\"frozen\" />"}
 
         _any ->
           {"", ""}
@@ -575,9 +568,7 @@ defmodule Elixlsx.XMLTemplates do
 
     """
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="#{len}" uniqueCount="#{
-      len
-    }">
+    <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="#{len}" uniqueCount="#{len}">
     """ <>
       Enum.map_join(stringlist, fn {_, value} ->
         # the only two characters that *must* be replaced for safe XML encoding are & and <:


### PR DESCRIPTION
Generating large tables (more than thousands of rows) takes a very long time.

I looked at the internal Sheet implementation and tried to rewrite it from a list of lists to a map of maps.

The result was a drastic speedup in generating large tables:

|number of rows|current implementation|new implementation|speedup|
|-|-|-|-|
|10k rows|16s|0.7s|~23x|
|30k rows|154s|2.4s|~64x|
|50k rows|448s|2.7s|~166x|
|100k rows|1716s|5.7s|~301x|
|1M rows|didn't wait :-)|65.7s|?|

(unscientific time measurement of generating tables with a given number of rows and 10 columns)

All my tests and use cases work with the new implementation, but it would definitely take more testing. Please don't take the pull request as final yet. I just want to make sure at this point that you would be interested in the modification and would consider including it in the main branch.

Anyone is of course welcome to test on generating their own data.