### PR TITLE
feat: support hidden sheet states

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -28,6 +28,7 @@ defmodule Elixlsx.Sheet do
             group_rows: [],
             merge_cells: [],
             pane_freeze: nil,
+            state: :visible,
             show_grid_lines: true,
             data_validations: []
 
@@ -40,6 +41,7 @@ defmodule Elixlsx.Sheet do
           group_rows: list(rowcol_group),
           merge_cells: [{String.t(), String.t()}],
           pane_freeze: {number, number} | nil,
+          state: :visible | :hidden | :very_hidden,
           show_grid_lines: boolean(),
           data_validations: list({String.t(), String.t(), list(String.t()) | String.t()})
         }
@@ -51,8 +53,9 @@ defmodule Elixlsx.Sheet do
   The name can be up to 31 characters long.
   """
   @spec with_name(String.t()) :: Sheet.t()
-  def with_name(name) do
-    %Sheet{name: name}
+  def with_name(name, opts \\ []) do
+    state = Keyword.get(opts, :state, :visible)
+    %Sheet{name: name, state: state}
   end
 
   defp split_cell_content_props(cell) do

--- a/lib/elixlsx/xml_templates.ex
+++ b/lib/elixlsx/xml_templates.ex
@@ -123,8 +123,14 @@ defmodule Elixlsx.XMLTemplates do
       }
     end
 
+    state = case sheet_info.state do
+      :hidden -> "hidden"
+      :very_hidden -> "veryHidden"
+      _ -> "visible"
+    end
+
     """
-    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="visible" r:id="#{
+    <sheet name="#{xml_escape(sheet_info.name)}" sheetId="#{sheet_comp_info.sheetId}" state="#{state}" r:id="#{
       sheet_comp_info.rId
     }"/>
     """


### PR DESCRIPTION
Supports `hidden` and `veryHidden` sheet states.

These states allow us to hide sheets from interfaces.