### PR TITLE
fix Sheet.add_data_validations typespec

### DIFF
--- a/lib/elixlsx/sheet.ex
+++ b/lib/elixlsx/sheet.ex
@@ -222,7 +222,7 @@ defmodule Elixlsx.Sheet do
     %{sheet | pane_freeze: nil}
   end
 
-  @spec add_data_validations(Sheet.t(), String.t(), String.t(), list(String.t())) :: Sheet.t()
+  @spec add_data_validations(Sheet.t(), String.t(), String.t(), String.t() | list(String.t())) :: Sheet.t()
   def add_data_validations(sheet, start_cell, end_cell, values) do
     %{sheet | data_validations: [{start_cell, end_cell, values} | sheet.data_validations]}
   end


### PR DESCRIPTION
Hi 👋

This PR fixes `Sheet.add_data_validations` typespec, including currently supported use case when instead of a values list the user passes one string with a reference within excel (e.g. `"RefSheet!$A$2:$A$32"`).

```elixir
The function call will not succeed.

Elixlsx.Sheet.add_data_validations(_sheet :: any(), <<_::8, _::size(1)>>, <<_::8, _::size(1)>>, <<_::8, _::size(1)>>)

breaks the contract
(t(), String.t(), String.t(), [String.t()]) :: t()
```

Thanks!